### PR TITLE
Add progress bar for remaining questions

### DIFF
--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
     <!-- Jeopardy Board and Modals -->
     <div id="jeopardy-board" class="hidden"></div>
     <div id="scoreboard" class="hidden"></div>
+    <div id="progress" class="hidden"></div>
 
     <div id="question-modal" class="hidden">
       <div id="modal-content">

--- a/inline-select.js
+++ b/inline-select.js
@@ -37,6 +37,7 @@ function startSelectedGame(mode, names = []) {
   document.getElementById('topic-selector').classList.add('hidden');
   document.getElementById('jeopardy-board').classList.remove('hidden');
   document.getElementById('scoreboard').classList.remove('hidden');
+  document.getElementById('progress').classList.remove('hidden');
   loadQuestions(selectedTopic, selectedExam);
 }
 
@@ -90,6 +91,7 @@ function goHome() {
   document.getElementById('question-modal').classList.add('hidden');
   document.getElementById('celebration-modal').classList.add('hidden');
   document.getElementById('scoreboard').classList.add('hidden');
+  document.getElementById('progress').classList.add('hidden');
   document.querySelectorAll('#topic-selector .exam-dropdown').forEach(dd => dd.classList.add('hidden'));
   document.getElementById('instructions').scrollIntoView();
 }

--- a/script.js
+++ b/script.js
@@ -1,5 +1,6 @@
 let currentQuestions = {};
 let remainingQuestions = 0;
+let totalQuestions = 0;
 let players = [];
 let currentPlayerIndex = 0;
 let maxPossibleScore = 0;
@@ -54,6 +55,7 @@ function buildBoard() {
   const categories = Object.keys(currentQuestions);
   board.style.gridTemplateColumns = `repeat(${categories.length}, 1fr)`;
   remainingQuestions = 0;
+  totalQuestions = 0;
   maxPossibleScore = 0;
 
   // header row
@@ -74,6 +76,7 @@ function buildBoard() {
       if (q) {
         cell.onclick = () => showQuestion(q, cell);
         remainingQuestions++;
+        totalQuestions++;
         maxPossibleScore += q.points;
       } else {
         cell.classList.add('hidden');
@@ -81,6 +84,12 @@ function buildBoard() {
       board.appendChild(cell);
     });
   });
+
+  const progressEl = document.getElementById('progress');
+  if (progressEl) {
+    progressEl.style.width = '0%';
+    progressEl.classList.remove('hidden');
+  }
 }
 
 function showQuestion(questionObj, cell) {
@@ -150,6 +159,12 @@ function closeQuestionModal() {
   document.getElementById('submitted-answer').classList.add('hidden');
   document.getElementById('award-controls').classList.add('hidden');
   remainingQuestions--;
+  const progressEl = document.getElementById('progress');
+  if (progressEl && totalQuestions > 0) {
+    const answered = totalQuestions - remainingQuestions;
+    const percent = (answered / totalQuestions) * 100;
+    progressEl.style.width = `${percent}%`;
+  }
   nextPlayer();
 
   if (remainingQuestions === 0) {

--- a/style.css
+++ b/style.css
@@ -217,6 +217,15 @@ button {
   font-size: 18px;
 }
 
+#progress {
+  height: 8px;
+  background-color: #4caf50;
+  width: 0;
+  margin-top: 8px;
+  border-radius: 4px;
+  transition: width 0.3s ease;
+}
+
 .player-score button {
   margin-left: 4px;
   padding: 2px 6px;
@@ -245,6 +254,10 @@ button {
 
   #scoreboard {
     font-size: 16px;
+  }
+
+  #progress {
+    height: 6px;
   }
 
   .player-score button {


### PR DESCRIPTION
## Summary
- show a progress bar next to the scoreboard
- style the progress bar
- compute progress in buildBoard and update after answering questions
- hide/show progress bar when changing screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68586c7117f4832298be06da49fe437f