### PR TITLE
Integrate ethics study deck

### DIFF
--- a/data/ethics-flashcards.js
+++ b/data/ethics-flashcards.js
@@ -1,0 +1,49 @@
+window.ethicsFlashcards = {
+  "Chapter 1: Ethics and the Examined Life": [
+    { question: "Ethics", answer: "The philosophical study of morality—how we ought to live and why." },
+    { question: "Morality", answer: "Beliefs about right and wrong actions and good or bad persons or character." },
+    { question: "Moral philosophy", answer: "Systematic study of moral concepts and theories, reflecting critically on ethical beliefs." },
+    { question: "Descriptive ethics", answer: "The scientific study of moral beliefs and practices, describing how people actually behave." },
+    { question: "Normative ethics", answer: "The study of principles, rules, or theories that guide actions and judgments about right or wrong." },
+    { question: "Metaethics", answer: "The study of the meaning and logical structure of moral beliefs." },
+    { question: "Applied ethics", answer: "The application of moral norms to specific moral issues or cases, especially in professions like medicine or law." }
+  ],
+
+  "Chapter 2: Subjectivism, Relativism, and Emotivism": [
+    { question: "Subjective relativism", answer: "The view that an action is morally right if one approves of it; morality is relative to individuals." },
+    { question: "Cultural relativism", answer: "The belief that morality is determined by cultural norms; actions are morally right if a culture approves of them." },
+    { question: "Moral objectivism", answer: "The view that some moral standards are objectively correct and valid for everyone, regardless of opinion." },
+    { question: "Emotivism", answer: "The view that moral utterances express emotions or attitudes rather than objective facts." },
+    { question: "Cognitivism", answer: "The view that moral statements can be true or false because they express beliefs or propositions." },
+    { question: "Noncognitivism", answer: "The view that moral statements are neither true nor false; they do not state facts but express feelings or attitudes." }
+  ],
+
+  "Chapter 3: Evaluating Moral Arguments": [
+    { question: "Argument", answer: "A set of statements, one of which (the conclusion) is supported by the others (premises)." },
+    { question: "Premise", answer: "A supporting statement in an argument intended to provide evidence for the conclusion." },
+    { question: "Conclusion", answer: "The statement in an argument that the premises support and aim to establish." },
+    { question: "Validity", answer: "A logical relationship where, if the premises are true, the conclusion must also be true." },
+    { question: "Soundness", answer: "An argument that is valid and whose premises are actually true." },
+    { question: "Moral statement", answer: "A statement asserting that an action is right or wrong, or a person or character is good or bad." },
+    { question: "Nonmoral statement", answer: "A statement that describes states of affairs or facts without moral evaluation." }
+  ],
+
+  "Chapter 4: Ethical Egoism and Utilitarianism": [
+    { question: "Ethical egoism", answer: "The view that the morally right action is the one that produces the greatest balance of good over harm for oneself." },
+    { question: "Utilitarianism", answer: "The view that right actions are those producing the greatest overall happiness for everyone affected." },
+    { question: "Act-utilitarianism", answer: "The view that each individual action is morally right if it produces more overall happiness than alternative actions." },
+    { question: "Rule-utilitarianism", answer: "The view that the morally right action is the one covered by a rule that, if generally followed, would produce the most overall happiness." },
+    { question: "Principle of utility", answer: "Jeremy Bentham's principle that approves actions that increase happiness and disapproves actions that diminish it." },
+    { question: "Consequentialism", answer: "The theory that moral actions are judged solely by their outcomes or consequences." }
+  ],
+
+  "Chapter 5: Kantian Ethics, Natural Law Theory, and Virtue Ethics": [
+    { question: "Deontology", answer: "Ethical theories that judge morality based on rules and duties rather than consequences." },
+    { question: "Categorical imperative", answer: "Kant's principle stating an action is morally right if it can be universalized consistently without contradiction." },
+    { question: "Means-end principle", answer: "Kant's principle that we must treat people as ends in themselves, never merely as means to an end." },
+    { question: "Natural law theory", answer: "The view that morally right actions follow the dictates of nature and are discoverable by reason." },
+    { question: "Doctrine of double effect", answer: "The principle stating an action causing serious harm may be permissible if the harm is an unintended side-effect of promoting a good end." },
+    { question: "Virtue ethics", answer: "Ethical theory emphasizing moral character and virtues rather than rules or consequences." },
+    { question: "Eudaimonia", answer: "Aristotle's concept of human flourishing achieved through developing virtues and practical wisdom." }
+  ]
+};

--- a/flashcards.html
+++ b/flashcards.html
@@ -41,6 +41,7 @@
   <script src="data/critical-thinking-final.js"></script>
   <script src="data/intro-philosophy.js"></script>
   <script src="data/intro-philosophy-final.js"></script>
+  <script src="data/ethics-flashcards.js"></script>
   <script src="flashcards.js"></script>
 </body>
 </html>

--- a/flashcards.js
+++ b/flashcards.js
@@ -1,25 +1,36 @@
 // Aggregate question sets into a single object keyed by course
+function mergeSets(target, source) {
+  Object.keys(source).forEach(cat => {
+    if (!target[cat]) target[cat] = [];
+    target[cat] = target[cat].concat(source[cat]);
+  });
+}
+
 function buildFlashcards() {
   const courses = ['introPhilosophy', 'criticalThinking', 'ethics'];
   const flashcards = {};
 
   courses.forEach(course => {
     flashcards[course] = {};
+
+    const customSet = window[`${course}Flashcards`];
+    if (customSet) {
+      mergeSets(flashcards[course], customSet);
+      return;
+    }
+
     const variants = [
       `${course}Questions`,
       `${course}MidtermQuestions`,
       `${course}FinalQuestions`
     ];
+
     variants.forEach(name => {
       const data = window[name];
-      if (data) {
-        Object.keys(data).forEach(cat => {
-          if (!flashcards[course][cat]) flashcards[course][cat] = [];
-          flashcards[course][cat] = flashcards[course][cat].concat(data[cat]);
-        });
-      }
+      if (data) mergeSets(flashcards[course], data);
     });
   });
+
   return flashcards;
 }
 

--- a/trivia.html
+++ b/trivia.html
@@ -37,6 +37,7 @@
   <script src="data/critical-thinking-final.js"></script>
   <script src="data/intro-philosophy.js"></script>
   <script src="data/intro-philosophy-final.js"></script>
+  <script src="data/ethics-flashcards.js"></script>
   <script src="flashcards.js"></script>
   <script src="trivia.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- support custom course flashcards via `mergeSets` in `flashcards.js`
- add dedicated flashcard dataset for Ethics
- load the new data on Flashcards and Trivia pages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68592c7dacf483229b8edc408500b4b4