### PR TITLE
Add clickable citation investigation

### DIFF
--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -500,6 +500,20 @@ button {
   opacity: 1;
 }
 
+.citation-part {
+  cursor: pointer;
+  padding: 2px 4px;
+  border-radius: 4px;
+}
+
+.citation-part.selected {
+  background-color: #4caf50;
+}
+
+.error-highlight {
+  background-color: #e91e63;
+}
+
 @media (min-width: 768px) {
   #topic-selector {
     flex-direction: row;

--- a/writing/citation.html
+++ b/writing/citation.html
@@ -15,8 +15,8 @@
     <p class="instructions">Accurate citations help readers locate your sources, strengthen your credibility, and prevent plagiarism. Philosophical writing relies heavily on accurate referencing.</p>
     <div id="citation-game">
       <p id="citation-prompt"></p>
-      <textarea id="citation-input" rows="3" style="width:90%;"></textarea><br>
-      <button id="citation-reveal">Reveal Better Answer</button>
+      <button id="citation-giveup">I don't see any mistakes</button>
+      <div id="citation-feedback" class="hidden"></div>
       <div id="citation-answer" class="hidden"></div>
       <button id="citation-next" class="hidden">Next</button>
     </div>

--- a/writing/citation.js
+++ b/writing/citation.js
@@ -1,24 +1,40 @@
 const citationExercises = [
   {
-    incorrect: 'Kant claims that moral rules must be universal without exception (Kant, Groundwork, p. 31).',
+    segments: [
+      { text: 'Kant claims that moral rules must be universal without exception (' },
+      { text: 'Kant', error: true },
+      { text: ', Groundwork, p. 31).' }
+    ],
     apa: 'Kant (1785/1997) claims that moral rules must be universal without exception (<em>Groundwork of the Metaphysics of Morals</em>, p. 31).',
     mla: 'Kant claims that moral rules must be universal without exception (<em>Groundwork of the Metaphysics of Morals</em> 31).',
     explanation: 'APA needs the publication date and translator; MLA omits the date but italicizes the title and gives the page number without "p.".'
   },
   {
-    incorrect: 'Aquinas argues that moral actions follow natural law (Summa Theologica, Aquinas, p. 423).',
+    segments: [
+      { text: 'Aquinas argues that moral actions follow natural law (' },
+      { text: 'Summa Theologica, Aquinas', error: true },
+      { text: ', p. 423).' }
+    ],
     apa: 'Aquinas (1274/1947) argues that moral actions must follow natural law (<em>Summa Theologica</em>, p. 423).',
     mla: 'Aquinas argues moral actions must follow natural law (<em>Summa Theologica</em> 423).',
     explanation: 'Include author, date, and translator in APA; MLA keeps it simpler with the title and page number.'
   },
   {
-    incorrect: 'Nussbaum claims that ethics must consider human capabilities ("Ethics and Capabilities," Philosophy Review, Martha Nussbaum, 2011, 56).',
+    segments: [
+      { text: 'Nussbaum claims that ethics must consider human capabilities ("Ethics and Capabilities,"' },
+      { text: ' Philosophy Review, Martha Nussbaum', error: true },
+      { text: ', 2011, 56).' }
+    ],
     apa: 'Nussbaum, M. C. (2011). Ethics and capabilities. <em>Philosophy Review</em>, 23(2), 56.',
     mla: 'Nussbaum, Martha C. "Ethics and Capabilities." <em>Philosophy Review</em>, vol. 23, no. 2, 2011, p. 56.',
     explanation: 'APA uses initials and year in parentheses; MLA lists the volume and issue with "vol." and "no.".'
   },
   {
-    incorrect: 'Rachels claims euthanasia can be morally permissible ("The Morality of Euthanasia," James Rachels, Ethics Collection, 1998, p. 104).',
+    segments: [
+      { text: 'Rachels claims euthanasia can be morally permissible ("The Morality of Euthanasia,"' },
+      { text: ' James Rachels', error: true },
+      { text: ', Ethics Collection, 1998, p. 104).' }
+    ],
     apa: 'Rachels, J. (1998). The morality of euthanasia. In J. Smith (Ed.), <em>Ethics Collection</em> (pp. 104–116). Routledge.',
     mla: 'Rachels, James. "The Morality of Euthanasia." <em>Ethics Collection</em>, edited by John Smith, Routledge, 1998, pp. 104–116.',
     explanation: 'APA specifies the editor and page range; MLA introduces the editor with "edited by".'
@@ -27,12 +43,34 @@ const citationExercises = [
 
 let citationIndex = 0;
 
-function showCitation() {
+function buildCitation() {
   const ex = citationExercises[citationIndex];
-  document.getElementById('citation-prompt').innerText = ex.incorrect;
-  document.getElementById('citation-input').value = '';
+  const container = document.getElementById('citation-prompt');
+  container.innerHTML = '';
+  ex.segments.forEach((seg, idx) => {
+    const span = document.createElement('span');
+    span.innerText = seg.text;
+    span.classList.add('citation-part');
+    span.dataset.index = idx;
+    span.addEventListener('click', () => handleClick(idx, span));
+    container.appendChild(span);
+  });
+  document.getElementById('citation-feedback').classList.add('hidden');
   document.getElementById('citation-answer').classList.add('hidden');
   document.getElementById('citation-next').classList.add('hidden');
+}
+
+function handleClick(idx, span) {
+  const seg = citationExercises[citationIndex].segments[idx];
+  const feedback = document.getElementById('citation-feedback');
+  if (seg.error) {
+    span.classList.add('selected');
+    feedback.innerText = 'Correct!';
+    revealCitation();
+  } else {
+    feedback.innerText = 'Not quite. Try again.';
+  }
+  feedback.classList.remove('hidden');
 }
 
 function revealCitation() {
@@ -41,12 +79,23 @@ function revealCitation() {
   ansDiv.innerHTML = `<strong>APA:</strong> ${ex.apa}<br><strong>MLA:</strong> ${ex.mla}<br><em>${ex.explanation}</em>`;
   ansDiv.classList.remove('hidden');
   document.getElementById('citation-next').classList.remove('hidden');
+  highlightErrors();
 }
 
-document.getElementById('citation-reveal').addEventListener('click', revealCitation);
+function highlightErrors() {
+  const ex = citationExercises[citationIndex];
+  ex.segments.forEach((seg, idx) => {
+    if (seg.error) {
+      const span = document.querySelector(`#citation-prompt span[data-index="${idx}"]`);
+      if (span) span.classList.add('error-highlight');
+    }
+  });
+}
+
+document.getElementById('citation-giveup').addEventListener('click', revealCitation);
 document.getElementById('citation-next').addEventListener('click', () => {
   citationIndex = (citationIndex + 1) % citationExercises.length;
-  showCitation();
+  buildCitation();
 });
 
-window.addEventListener('DOMContentLoaded', showCitation);
+window.addEventListener('DOMContentLoaded', buildCitation);


### PR DESCRIPTION
## Summary
- revamp citation investigator UI to remove freeform answers
- highlight citation parts as clickable items
- show feedback when user chooses part or opts to give up
- style clickable citation spans

## Testing
- `node --check writing/citation.js`

------
https://chatgpt.com/codex/tasks/task_e_685948631df48322a800a6fd3d1d74b4