### PR TITLE
Fix review game links and hide courses on load

### DIFF
--- a/jeopardy/index.html
+++ b/jeopardy/index.html
@@ -18,9 +18,9 @@
       <div class="course">
         <h3>Intro to Philosophy</h3>
         <div class="game-links">
-          <button onclick="location.href='flashcards.html?course=introPhilosophy'">Flashcards</button>
-          <button onclick="location.href='trivia.html?course=introPhilosophy'">Trivia</button>
-          <button onclick="location.href='intro-philosophy-chat.html'">Chat</button>
+          <button onclick="location.href='../flashcards/flashcards.html?course=introPhilosophy'">Flashcards</button>
+          <button onclick="location.href='../trivia/trivia.html?course=introPhilosophy'">Trivia</button>
+          <button onclick="location.href='../chatbots/intro-philosophy-chat.html'">Chat</button>
         </div>
         <button class="topic-btn" data-topic="introPhilosophy">Game Board</button>
         <div class="exam-dropdown hidden">
@@ -31,9 +31,9 @@
       <div class="course">
         <h3>Critical Thinking</h3>
         <div class="game-links">
-          <button onclick="location.href='flashcards.html?course=criticalThinking'">Flashcards</button>
-          <button onclick="location.href='trivia.html?course=criticalThinking'">Trivia</button>
-          <button onclick="location.href='fallacy.html'">Fallacy Detective</button>
+          <button onclick="location.href='../flashcards/flashcards.html?course=criticalThinking'">Flashcards</button>
+          <button onclick="location.href='../trivia/trivia.html?course=criticalThinking'">Trivia</button>
+          <button onclick="location.href='../fallacy-detection/fallacy.html'">Fallacy Detective</button>
           <button onclick="location.href='../argument-reconstruction/critical-thinking.html'">Reconstruction</button>
         </div>
         <button class="topic-btn" data-topic="criticalThinking">Game Board</button>
@@ -45,9 +45,9 @@
       <div class="course">
         <h3>Ethics</h3>
         <div class="game-links">
-          <button onclick="location.href='flashcards.html?course=ethics'">Flashcards</button>
-          <button onclick="location.href='trivia.html?course=ethics'">Trivia</button>
-          <button onclick="location.href='ethics-chat.html'">Chat</button>
+          <button onclick="location.href='../flashcards/flashcards.html?course=ethics'">Flashcards</button>
+          <button onclick="location.href='../trivia/trivia.html?course=ethics'">Trivia</button>
+          <button onclick="location.href='../chatbots/ethics-chat.html'">Chat</button>
         </div>
         <button class="topic-btn" data-topic="ethics">Game Board</button>
         <div class="exam-dropdown hidden">

--- a/jeopardy/inline-select.js
+++ b/jeopardy/inline-select.js
@@ -148,5 +148,9 @@ const startParams = new URLSearchParams(window.location.search);
 const startTopic = startParams.get('topic');
 const startExam = startParams.get('exam');
 if (startTopic && startExam) {
+  document.getElementById('topic-selector').classList.add('hidden');
+  document.getElementById('quote-game').classList.add('hidden');
+  const instr = document.getElementById('instructions');
+  if (instr) instr.classList.add('hidden');
   showModeModal(startTopic, startExam);
 }


### PR DESCRIPTION
## Summary
- fix relative paths to other games in `jeopardy/index.html`
- when launching a review game via URL parameters, hide the course links and quote game so only the mode selection dialog is visible

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685968f2b9c08322b099bf71671bc005