### PR TITLE
Fix quote sidebar position and arrow toggle

### DIFF
--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -334,6 +334,18 @@ button {
   transform: translate(100%, -50%);
 }
 
+@media (min-width: 768px) {
+  #quote-sidebar {
+    bottom: 0;
+    top: auto;
+    transform: none;
+  }
+
+  #quote-sidebar.collapsed {
+    transform: translateX(100%);
+  }
+}
+
 #quote-toggle {
   position: absolute;
   left: -32px;

--- a/jeopardy/who-said-it.js
+++ b/jeopardy/who-said-it.js
@@ -86,7 +86,12 @@ showRandomQuote();
 const sidebar = document.getElementById('quote-sidebar');
 const toggleBtn = document.getElementById('quote-toggle');
 if (sidebar && toggleBtn) {
+  // Set initial arrow based on sidebar state
+  toggleBtn.innerHTML = sidebar.classList.contains('collapsed') ? '&#x276E;' : '&#x276F;';
+
   toggleBtn.addEventListener('click', () => {
-    sidebar.classList.toggle('collapsed');
+    const collapsed = sidebar.classList.toggle('collapsed');
+    // When collapsed show left-pointing arrow, otherwise point inward
+    toggleBtn.innerHTML = collapsed ? '&#x276E;' : '&#x276F;';
   });
 }


### PR DESCRIPTION
## Summary
- place the quote sidebar at the bottom on wide screens
- translate collapsed sidebar horizontally on wide screens
- change toggle arrow based on sidebar state

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685971c9a30c83228bd0e7591a3324c2