### PR TITLE
Add export and quiz mode buttons to flashcards

### DIFF
--- a/flashcards/flashcards.html
+++ b/flashcards/flashcards.html
@@ -31,6 +31,8 @@
       <p id="flashcard-answer" class="hidden"></p>
       <button id="show-answer">Show Answer</button>
       <button id="next-card">Next Card</button>
+      <button id="export-cards">Export</button>
+      <button id="quiz-mode">Quiz Mode</button>
     </div>
   </div>
 

--- a/flashcards/flashcards.js
+++ b/flashcards/flashcards.js
@@ -92,6 +92,40 @@ function nextCard() {
   loadCard();
 }
 
+function exportCards() {
+  if (!currentCards.length) return;
+  const format = prompt('Export as json or csv?', 'json');
+  if (!format) return;
+  let data, mime, ext;
+  if (format.toLowerCase().startsWith('c')) {
+    const rows = currentCards.map(c => {
+      const q = '"' + c.question.replace(/"/g, '""') + '"';
+      const a = '"' + c.answer.replace(/"/g, '""') + '"';
+      return `${q},${a}`;
+    });
+    data = 'question,answer\n' + rows.join('\n');
+    mime = 'text/csv';
+    ext = 'csv';
+  } else {
+    data = JSON.stringify(currentCards, null, 2);
+    mime = 'application/json';
+    ext = 'json';
+  }
+  const blob = new Blob([data], { type: mime });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `flashcards.${ext}`;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function startQuiz() {
+  const course = document.getElementById('course-select').value;
+  const dest = course ? `../trivia/trivia.html?course=${course}` : '../trivia/trivia.html';
+  window.location.href = dest;
+}
+
 document.getElementById('course-select').addEventListener('change', e => {
   const course = e.target.value;
   populateCategories(course);
@@ -105,6 +139,8 @@ document.getElementById('category-select').addEventListener('change', e => {
 
 document.getElementById('show-answer').addEventListener('click', showAnswer);
 document.getElementById('next-card').addEventListener('click', nextCard);
+document.getElementById('export-cards').addEventListener('click', exportCards);
+document.getElementById('quiz-mode').addEventListener('click', startQuiz);
 
 function getParam(name) {
   const params = new URLSearchParams(window.location.search);


### PR DESCRIPTION
## Summary
- add Export and Quiz Mode buttons in `flashcards.html`
- implement `exportCards` and `startQuiz` in `flashcards.js`
- wire up the new buttons to export cards and launch trivia

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68598cf0b388832285dcbfda4fdd6bbf