### PR TITLE
Fix flashcards export and prevent multi-clicks

### DIFF
--- a/chatbots/ethics-chat-engine.js
+++ b/chatbots/ethics-chat-engine.js
@@ -4,6 +4,7 @@
   const bots = window.ethicalChatbots || {};
   let current = 'Philosophy Student';
   let exchangeIndex = 0;
+  let awaitingChoice = false;
   const alignmentScores = {};
   const speakerClasses = {
     'John Stuart Mill': 'speaker-mill',
@@ -38,6 +39,7 @@
   }
 
   function showOptions(responses, view) {
+    awaitingChoice = true;
     controls.innerHTML = '';
     Object.keys(responses).forEach(option => {
       const btn = document.createElement('button');
@@ -49,6 +51,9 @@
   }
 
   async function handleChoice(option, reply, view) {
+    if (!awaitingChoice) return;
+    awaitingChoice = false;
+    controls.querySelectorAll('button').forEach(b => b.disabled = true);
     await addMessage('You', option, 'chat-user');
     await addMessage(current, reply);
     if (option === view) {

--- a/chatbots/intro-philosophy-chatbot-revised.js
+++ b/chatbots/intro-philosophy-chatbot-revised.js
@@ -135,6 +135,7 @@ const philosophyChatSteps = [
   const chatBox = document.getElementById('chat-box');
   const controls = document.getElementById('chat-controls');
   let stepIndex = 0;
+  let awaitingChoice = false;
   const speakerClasses = {
     'Philosophy Student': 'speaker-student',
     'Thales': 'speaker-thales',
@@ -166,6 +167,7 @@ const philosophyChatSteps = [
   }
 
   function showChoices(step) {
+    awaitingChoice = true;
     controls.innerHTML = '';
     step.choices.forEach(opt => {
       const btn = document.createElement('button');
@@ -177,6 +179,9 @@ const philosophyChatSteps = [
   }
 
   async function handleChoice(choice) {
+    if (!awaitingChoice) return;
+    awaitingChoice = false;
+    controls.querySelectorAll('button').forEach(b => b.disabled = true);
     await addMessage('You', choice, 'chat-user');
     const step = philosophyChatSteps[stepIndex];
     controls.innerHTML = '';

--- a/flashcards/flashcards.js
+++ b/flashcards/flashcards.js
@@ -35,6 +35,9 @@ function buildFlashcards() {
 }
 
 const flashcards = buildFlashcards();
+if (typeof window !== 'undefined') {
+  window.flashcards = flashcards;
+}
 let currentCards = [];
 let cardIndex = 0;
 


### PR DESCRIPTION
## Summary
- expose `flashcards` on `window` so trivia & flashcards pages can load questions
- disable answer buttons in ethics and intro philosophy chatbots after a choice

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68599b77c484832291e8c6204675e698