### PR TITLE
Add home navigation and activity suggestions

### DIFF
--- a/debate-duel/debate-duel.html
+++ b/debate-duel/debate-duel.html
@@ -47,6 +47,7 @@
     </div>
   </div>
   <script src="debate-duel.js"></script>
+  <script src="../next-activity.js"></script>
   <script src="../page-header.js"></script>
 </body>
 </html>

--- a/debate-duel/debate-duel.js
+++ b/debate-duel/debate-duel.js
@@ -145,6 +145,7 @@ function showSummary() {
                `Logical fallacies used: ${counts.fallacious}`;
   document.getElementById('summary-text').innerText = text;
   document.getElementById('summary').classList.remove('hidden');   document.getElementById('summary').hidden = false;
+  showNextActivity('criticalThinking');
 }
 
 document.getElementById('start-btn').addEventListener('click', showTopics);

--- a/next-activity.js
+++ b/next-activity.js
@@ -1,0 +1,36 @@
+function getCourse() {
+  const params = new URLSearchParams(window.location.search);
+  return params.get('course');
+}
+
+function showNextActivity(course) {
+  const container = document.querySelector('.container');
+  if (!container) return;
+  const map = {
+    introPhilosophy: {
+      label: 'Flashcards',
+      url: '../flashcards/flashcards.html?course=introPhilosophy'
+    },
+    criticalThinking: {
+      label: 'Flashcards',
+      url: '../flashcards/flashcards.html?course=criticalThinking'
+    },
+    ethics: { label: 'Flashcards', url: '../flashcards/flashcards.html?course=ethics' }
+  };
+  const rec = map[course];
+  const div = document.createElement('div');
+  div.id = 'next-activity';
+  const home = document.createElement('button');
+  home.textContent = 'Back to Home';
+  home.addEventListener('click', () => { window.location.href = '../index.html'; });
+  div.appendChild(home);
+  if (rec) {
+    const p = document.createElement('p');
+    const a = document.createElement('a');
+    a.href = rec.url;
+    a.textContent = `Next: ${rec.label}`;
+    p.appendChild(a);
+    div.appendChild(p);
+  }
+  container.appendChild(div);
+}

--- a/trivia/trivia.html
+++ b/trivia/trivia.html
@@ -47,6 +47,7 @@
   <script src="../jeopardy/data/ethics-flashcards.js"></script>
   <script src="flashcards.js"></script>
   <script src="trivia.js"></script>
+  <script src="../next-activity.js"></script>
   <script src="../page-header.js"></script>
 </body>
 </html>

--- a/trivia/trivia.js
+++ b/trivia/trivia.js
@@ -4,6 +4,7 @@ let currentTrivia = [];
 let triviaIndex = 0;
 let optionIndex = 0;
 let questionsAnswered = 0;
+let selectedCourse = '';
 
 function shuffle(arr) {
   for (let i = arr.length - 1; i > 0; i--) {
@@ -14,6 +15,7 @@ function shuffle(arr) {
 
 function loadTrivia(course) {
   if (!triviaQuestions[course]) return;
+  selectedCourse = course;
   currentTrivia = Object.values(triviaQuestions[course]).flat();
   shuffle(currentTrivia);
   triviaIndex = 0;
@@ -72,6 +74,7 @@ function submitTrivia(choice) {
       share.classList.remove('hidden');
       share.hidden = false;
     }
+    showNextActivity(selectedCourse || getParam('course'));
   }
 }
 

--- a/trolley/trolley.html
+++ b/trolley/trolley.html
@@ -37,6 +37,7 @@
     <div id="summary" class="hidden" hidden></div>
   </div>
   <script src="trolley.js"></script>
+  <script src="../next-activity.js"></script>
   <script src="../page-header.js"></script>
 </body>
 </html>

--- a/trolley/trolley.js
+++ b/trolley/trolley.js
@@ -97,6 +97,7 @@ function showSummary() {
   summaryDiv.innerHTML =
     `<p>You chose the utilitarian option ${pullCount} time(s) and refused ${inactionCount} time(s).</p>` +
     `<p>Consequences matter, but ethics also involves principles, rights, and virtues beyond mere calculation.</p>`;
+  showNextActivity('ethics');
 }
 
 


### PR DESCRIPTION
## Summary
- introduce `next-activity.js` helper for home button and recommendations
- include helper on Trivia, Trolley Problem, and Debate Duel pages
- show home button and next activity when each game ends

## Testing
- `node -e "require('./next-activity.js');"`
- `node -e "require('./trolley/trolley.js');"` *(fails: document not defined)*


------
https://chatgpt.com/codex/tasks/task_e_6859aabbdb548322adf063860ac07623