### PR TITLE
Fix timeline tooltip layering

### DIFF
--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -766,6 +766,7 @@ button {
   transition: opacity 0.2s;
   font-size: 14px;
   text-align: left;
+  z-index: 10;
 }
 
 #timeline-ticks {
@@ -800,6 +801,7 @@ button {
   transform: translateX(-50%);
   font-size: 12px;
   white-space: nowrap;
+  z-index: 0;
 }
 
 @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- ensure tooltip appears above tick labels on the interactive timeline

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859ac13baa8832284b420b8928148a1