### PR TITLE
Refactor flashcards to use dedicated sets

### DIFF
--- a/flashcards/flashcards.html
+++ b/flashcards/flashcards.html
@@ -51,12 +51,8 @@
   </div>
 
   <script src="../jeopardy/data/ethics.js"></script>
-  <script src="../jeopardy/data/ethics-final.js"></script>
   <script src="../jeopardy/data/critical-thinking.js"></script>
-  <script src="../jeopardy/data/critical-thinking-midterm.js"></script>
-  <script src="../jeopardy/data/critical-thinking-final.js"></script>
   <script src="../jeopardy/data/intro-philosophy.js"></script>
-  <script src="../jeopardy/data/intro-philosophy-final.js"></script>
   <script src="../jeopardy/data/intro-philosophy-flashcards.js"></script>
   <script src="../jeopardy/data/critical-thinking-flashcards.js"></script>
   <script src="../jeopardy/data/ethics-flashcards.js"></script>

--- a/flashcards/flashcards.js
+++ b/flashcards/flashcards.js
@@ -13,22 +13,10 @@ function buildFlashcards() {
   courses.forEach(course => {
     flashcards[course] = {};
 
-    const customSet = window[`${course}Flashcards`];
-    if (customSet) {
-      mergeSets(flashcards[course], customSet);
-      return;
+    const set = window[`${course}Flashcards`];
+    if (set) {
+      mergeSets(flashcards[course], set);
     }
-
-    const variants = [
-      `${course}Questions`,
-      `${course}MidtermQuestions`,
-      `${course}FinalQuestions`
-    ];
-
-    variants.forEach(name => {
-      const data = window[name];
-      if (data) mergeSets(flashcards[course], data);
-    });
   });
 
   return flashcards;


### PR DESCRIPTION
## Summary
- simplify `buildFlashcards` to only load `window.<course>Flashcards`
- stop including midterm/final question banks on the flashcards page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859b72f3e3883228c265b48d881a88f