### PR TITLE
Update flashcard layout and controls

### DIFF
--- a/flashcards/flashcards.html
+++ b/flashcards/flashcards.html
@@ -35,19 +35,14 @@
           </div>
           <div class="flip-card-back">
             <p id="flashcard-answer" class="hidden" hidden></p>
-            <div id="review-buttons" class="hidden">
-              <button data-result="easy">Easy</button>
-              <button data-result="hard">Hard</button>
-              <button data-result="review">Review again</button>
-            </div>
           </div>
         </div>
       </div>
-      <button id="show-answer">Show Answer</button>
-      <button id="prev-card">Prev Card</button>
-      <button id="next-card">Next Card</button>
-      <button id="export-cards">Export</button>
-      <button id="exit-cards" type="button">Exit</button>
+      <button id="exit-cards" class="flashcard-close" type="button">X</button>
+      <div class="flashcard-controls">
+        <button id="prev-card">Prev Card</button>
+        <button id="next-card">Next Card</button>
+      </div>
     </div>
   </div>
 

--- a/flashcards/flashcards.js
+++ b/flashcards/flashcards.js
@@ -66,8 +66,6 @@ function loadCard() {
     document.getElementById('flashcard-question').innerText = 'No cards available.';
     document.getElementById('flashcard-answer').classList.add('hidden');
     document.getElementById('flashcard-answer').hidden = true;
-    document.getElementById('review-buttons').classList.add('hidden');
-    document.getElementById('review-buttons').hidden = true;
     document.querySelector('#flashcard .flip-card').classList.remove('flipped');
     return;
   }
@@ -76,8 +74,6 @@ function loadCard() {
   document.getElementById('flashcard-answer').innerText = card.answer;
   document.getElementById('flashcard-answer').classList.add('hidden');
   document.getElementById('flashcard-answer').hidden = true;
-  document.getElementById('review-buttons').classList.add('hidden');
-  document.getElementById('review-buttons').hidden = true;
   document.querySelector('#flashcard .flip-card').classList.remove('flipped');
 }
 
@@ -85,8 +81,6 @@ function showAnswer() {
   document.querySelector('#flashcard .flip-card').classList.add('flipped');
   document.getElementById('flashcard-answer').classList.remove('hidden');
   document.getElementById('flashcard-answer').hidden = false;
-  document.getElementById('review-buttons').classList.remove('hidden');
-  document.getElementById('review-buttons').hidden = false;
 }
 
 function toggleFlip() {
@@ -95,8 +89,6 @@ function toggleFlip() {
     card.classList.remove('flipped');
     document.getElementById('flashcard-answer').classList.add('hidden');
     document.getElementById('flashcard-answer').hidden = true;
-    document.getElementById('review-buttons').classList.add('hidden');
-    document.getElementById('review-buttons').hidden = true;
   } else {
     showAnswer();
   }
@@ -165,21 +157,13 @@ document.getElementById('category-select').addEventListener('change', e => {
   if (course) loadCards(course, e.target.value);
 });
 
-document.getElementById('show-answer').addEventListener('click', showAnswer);
 document.querySelector('#flashcard .flip-card').addEventListener('click', toggleFlip);
 document.getElementById('next-card').addEventListener('click', nextCard);
 document.getElementById('prev-card').addEventListener('click', prevCard);
-document.getElementById('export-cards').addEventListener('click', exportCards);
 document.getElementById('exit-cards').addEventListener('click', () => {
   const flashcard = document.getElementById('flashcard');
   flashcard.classList.add('hidden');
   flashcard.hidden = true;
-});
-document.getElementById('review-buttons').addEventListener('click', e => {
-  const result = e.target.dataset.result;
-  if (!result) return;
-  saveResult(result);
-  nextCard();
 });
 
 // Keyboard navigation
@@ -190,8 +174,8 @@ document.addEventListener('keydown', (e) => {
     nextCard();
   } else if (e.key === 'ArrowLeft') {
     prevCard();
-  } else if (e.key === 'ArrowDown') {
-    showAnswer();
+  } else if (e.key === 'Shift') {
+    toggleFlip();
   }
 });
 

--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -901,3 +901,21 @@ button {
   margin: 0 auto 20px;
 }
 
+#flashcard {
+  position: relative;
+}
+
+.flashcard-close {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+}
+
+.flashcard-controls {
+  position: absolute;
+  bottom: 8px;
+  left: 0;
+  width: 100%;
+  text-align: center;
+}
+


### PR DESCRIPTION
## Summary
- remove review and export controls from flashcards
- move navigation buttons inside the flashcard container
- add exit button styled as an `X`
- allow flipping cards with the Shift key
- update CSS to position controls within the card

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6859c5e955c8832295ae74c6aeb30706