### PR TITLE
Update trivia and flashcards filters

### DIFF
--- a/flashcards/flashcards.html
+++ b/flashcards/flashcards.html
@@ -14,14 +14,7 @@
   <div class="container">
     <h1>Flashcards</h1>
     <div>
-      <label for="course-select">Course:</label>
-      <select id="course-select">
-        <option value="">--Select--</option>
-        <option value="introPhilosophy">Intro to Philosophy</option>
-        <option value="criticalThinking">Critical Thinking</option>
-        <option value="ethics">Ethics</option>
-      </select>
-      <label for="category-select">Category:</label>
+      <label for="category-select">Topic:</label>
       <select id="category-select" disabled>
         <option value="all">All</option>
       </select>

--- a/flashcards/flashcards.js
+++ b/flashcards/flashcards.js
@@ -52,7 +52,10 @@ function populateCategories(course) {
   }
   const cats = Object.keys(flashcards[course]);
   catSelect.appendChild(new Option('All', 'all'));
-  cats.forEach(cat => catSelect.appendChild(new Option(cat, cat)));
+  cats.forEach(cat => {
+    const label = cat.replace(/^Chapter\s*\d+\s*:\s*/i, '');
+    catSelect.appendChild(new Option(label, cat));
+  });
   catSelect.disabled = false;
 }
 
@@ -155,18 +158,10 @@ function exportCards() {
   URL.revokeObjectURL(url);
 }
 
-document.getElementById('course-select').addEventListener('change', e => {
-  const course = e.target.value;
-  populateCategories(course);
-  if (course) {
-    loadCards(course);
-    if (window.updatePageHeader) updatePageHeader(course);
-  }
-});
+let selectedCourse = '';
 
 document.getElementById('category-select').addEventListener('change', e => {
-  const course = document.getElementById('course-select').value;
-  if (course) loadCards(course, e.target.value);
+  if (selectedCourse) loadCards(selectedCourse, e.target.value);
 });
 
 document.querySelector('#flashcard .flip-card').addEventListener('click', toggleFlip);
@@ -204,12 +199,10 @@ function getParam(name) {
 }
 
 window.addEventListener('DOMContentLoaded', () => {
-  const course = getParam('course');
-  if (course) {
-    const select = document.getElementById('course-select');
-    select.value = course;
-    populateCategories(course);
-    loadCards(course);
-    if (window.updatePageHeader) updatePageHeader(course);
+  selectedCourse = getParam('course');
+  if (selectedCourse) {
+    populateCategories(selectedCourse);
+    loadCards(selectedCourse);
+    if (window.updatePageHeader) updatePageHeader(selectedCourse);
   }
 });

--- a/help-modal.html
+++ b/help-modal.html
@@ -1,6 +1,5 @@
 <div class="modal-content">
   <h2>How This Works</h2>
   <p>Each activity on Philosophy MindGames runs entirely in your browser. Select a course or game and follow the prompts to test your knowledge.</p>
-  <p>Use the ? icons near page headings whenever you need a quick refresher.</p>
   <button id="help-close">Close</button>
 </div>

--- a/page-header.js
+++ b/page-header.js
@@ -48,14 +48,5 @@ window.addEventListener('DOMContentLoaded', () => {
   const h1 = document.querySelector('.container h1');
   updatePageHeader(courseKey);
 
-  if (h1) {
-    const help = document.createElement('a');
-    help.href = '#';
-    help.className = 'help-link';
-    help.textContent = '?';
-    help.addEventListener('click', (e) => { e.preventDefault(); openHelp(); });
-    h1.appendChild(help);
-  }
-
   loadHelpModal();
 });

--- a/trivia/trivia.html
+++ b/trivia/trivia.html
@@ -14,12 +14,9 @@
   <div class="container">
     <h1>Trivia Game</h1>
     <div>
-      <label for="trivia-course">Course:</label>
-      <select id="trivia-course">
-        <option value="">--Select--</option>
-        <option value="introPhilosophy">Intro to Philosophy</option>
-        <option value="criticalThinking">Critical Thinking</option>
-        <option value="ethics">Ethics</option>
+      <label for="category-select">Topic:</label>
+      <select id="category-select" disabled>
+        <option value="all">All</option>
       </select>
     </div>
 

--- a/trivia/trivia.js
+++ b/trivia/trivia.js
@@ -39,6 +39,22 @@ let optionIndex = 0;
 let questionsAnswered = 0;
 let selectedCourse = '';
 
+function populateCategories(course) {
+  const catSelect = document.getElementById('category-select');
+  catSelect.innerHTML = '';
+  if (!course || !triviaQuestions[course]) {
+    catSelect.disabled = true;
+    return;
+  }
+  const cats = Object.keys(triviaQuestions[course]);
+  catSelect.appendChild(new Option('All', 'all'));
+  cats.forEach(cat => {
+    const label = cat.replace(/^Chapter\s*\d+\s*:\s*/i, '');
+    catSelect.appendChild(new Option(label, cat));
+  });
+  catSelect.disabled = false;
+}
+
 function shuffle(arr) {
   for (let i = arr.length - 1; i > 0; i--) {
     const j = Math.floor(Math.random() * (i + 1));
@@ -46,10 +62,13 @@ function shuffle(arr) {
   }
 }
 
-function loadTrivia(course) {
+function loadTrivia(course, category = 'all') {
   if (!triviaQuestions[course]) return;
   selectedCourse = course;
-  currentTrivia = Object.values(triviaQuestions[course]).flat();
+  const all = category === 'all'
+    ? Object.values(triviaQuestions[course]).flat()
+    : (triviaQuestions[course][category] || []);
+  currentTrivia = all;
   shuffle(currentTrivia);
   triviaIndex = 0;
   questionsAnswered = 0;
@@ -137,13 +156,10 @@ document.addEventListener('keydown', (e) => {
   }
 });
 
-document.getElementById('trivia-course').addEventListener('change', e => {
-  const course = e.target.value;
-  if (course) {
-    loadTrivia(course);
-    if (window.updatePageHeader) updatePageHeader(course);
-  } else {
-    document.getElementById('trivia-game').classList.add('hidden');     document.getElementById('trivia-game').hidden = true;
+
+document.getElementById('category-select').addEventListener('change', e => {
+  if (selectedCourse) {
+    loadTrivia(selectedCourse, e.target.value);
   }
 });
 
@@ -153,12 +169,11 @@ function getParam(name) {
 }
 
 window.addEventListener('DOMContentLoaded', () => {
-  const course = getParam('course');
-  if (course) {
-    const select = document.getElementById('trivia-course');
-    select.value = course;
-    loadTrivia(course);
-    if (window.updatePageHeader) updatePageHeader(course);
+  selectedCourse = getParam('course');
+  if (selectedCourse) {
+    populateCategories(selectedCourse);
+    loadTrivia(selectedCourse);
+    if (window.updatePageHeader) updatePageHeader(selectedCourse);
   }
 
   const copy = document.getElementById('trivia-copy');


### PR DESCRIPTION
## Summary
- simplify flashcards dropdown to only filter by topic
- simplify trivia dropdown to only filter by topic
- strip chapter labels from dropdowns
- remove help question mark icons and update help text

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859c9d654ec8322a9c0f1b867aae292