### PR TITLE
Improve flashcard styles

### DIFF
--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -853,7 +853,8 @@ button {
   width: 100%;
   max-width: 600px;
   margin: 0 auto 20px;
-  min-height: 260px;
+  /* Increased min-height to better accommodate longer questions */
+  min-height: 40vh;
 }
 
 .flip-card-inner {
@@ -884,6 +885,8 @@ button {
   display: flex;
   flex-direction: column;
   justify-content: center;
+  align-items: center;
+  text-align: center;
 }
 
 .flip-card-back {
@@ -905,6 +908,12 @@ button {
 #flashcard p,
 #trivia-question {
   font-size: 1.2em;
+}
+
+#flashcard-question,
+#flashcard-answer {
+  /* Slightly larger text for better readability */
+  font-size: 1.4em;
 }
 
 #trivia-game,


### PR DESCRIPTION
## Summary
- tweak flashcard layout
  - raise `min-height` for `.flip-card`
  - center content on `.flip-card-front` and `.flip-card-back`
  - enlarge `#flashcard-question` and `#flashcard-answer`

## Testing
- `npm test` *(fails: cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6859fa02fe80832293f9aadca920dc6f