### PR TITLE
Replace header link text with icon

### DIFF
--- a/argument-reconstruction/critical-thinking.html
+++ b/argument-reconstruction/critical-thinking.html
@@ -9,7 +9,7 @@
 </head>
 <body>
   <nav id="top-nav">
-    <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
+    <a id="home-link" href="../index.html"><img id="site-icon" src="../icon.png" alt="Gaming Philosophy Class icon"></a>
   </nav>
   <header id="page-header" data-default-course="criticalThinking">Course • Activity</header>
   <div class="container">

--- a/argument-reconstruction/ethics.html
+++ b/argument-reconstruction/ethics.html
@@ -9,7 +9,7 @@
 </head>
 <body>
   <nav id="top-nav">
-    <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
+    <a id="home-link" href="../index.html"><img id="site-icon" src="../icon.png" alt="Gaming Philosophy Class icon"></a>
   </nav>
   <header id="page-header" data-default-course="ethics">Course • Activity</header>
   <div class="container">

--- a/argument-reconstruction/intro-philosophy.html
+++ b/argument-reconstruction/intro-philosophy.html
@@ -9,7 +9,7 @@
 </head>
 <body>
   <nav id="top-nav">
-    <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
+    <a id="home-link" href="../index.html"><img id="site-icon" src="../icon.png" alt="Gaming Philosophy Class icon"></a>
   </nav>
   <header id="page-header" data-default-course="introPhilosophy">Course • Activity</header>
   <div class="container">

--- a/chatbots/ethics-chat.html
+++ b/chatbots/ethics-chat.html
@@ -9,7 +9,7 @@
 </head>
 <body>
   <nav id="top-nav">
-    <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
+    <a id="home-link" href="../index.html"><img id="site-icon" src="../icon.png" alt="Gaming Philosophy Class icon"></a>
   </nav>
   <header id="page-header" data-default-course="ethics">Course • Activity</header>
   <div class="container">

--- a/chatbots/intro-philosophy-chat.html
+++ b/chatbots/intro-philosophy-chat.html
@@ -9,7 +9,7 @@
 </head>
 <body>
   <nav id="top-nav">
-    <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
+    <a id="home-link" href="../index.html"><img id="site-icon" src="../icon.png" alt="Gaming Philosophy Class icon"></a>
   </nav>
   <header id="page-header" data-default-course="introPhilosophy">Course • Activity</header>
   <div class="container">

--- a/debate-duel/debate-duel.html
+++ b/debate-duel/debate-duel.html
@@ -9,7 +9,7 @@
 </head>
 <body>
   <nav id="top-nav">
-    <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
+    <a id="home-link" href="../index.html"><img id="site-icon" src="../icon.png" alt="Gaming Philosophy Class icon"></a>
   </nav>
   <header id="page-header" data-default-course="criticalThinking">Course • Activity</header>
   <div class="container">

--- a/flashcards/flashcards.html
+++ b/flashcards/flashcards.html
@@ -10,7 +10,7 @@
 </head>
 <body class="flashcard-page">
   <nav id="top-nav">
-    <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
+    <a id="home-link" href="../index.html"><img id="site-icon" src="../icon.png" alt="Gaming Philosophy Class icon"></a>
   </nav>
   <header id="page-header" data-default-course="introPhilosophy">Course • Activity</header>
   <div class="container">

--- a/jeopardy/index.html
+++ b/jeopardy/index.html
@@ -9,7 +9,7 @@
 </head>
 <body>
   <nav id="top-nav" aria-label="Main">
-    <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
+    <a id="home-link" href="../index.html"><img id="site-icon" src="../icon.png" alt="Gaming Philosophy Class icon"></a>
   </nav>
   <header id="page-header" data-default-course="introPhilosophy">Course • Activity</header>
 

--- a/sherlock-mystery/sherlock.html
+++ b/sherlock-mystery/sherlock.html
@@ -9,7 +9,7 @@
 </head>
 <body>
   <nav id="top-nav">
-    <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
+    <a id="home-link" href="../index.html"><img id="site-icon" src="../icon.png" alt="Gaming Philosophy Class icon"></a>
   </nav>
   <header id="page-header" data-default-course="criticalThinking">Course • Activity</header>
   <div class="container">

--- a/timeline/timeline.html
+++ b/timeline/timeline.html
@@ -30,7 +30,7 @@
 </head>
 <body>
   <nav id="top-nav">
-    <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
+    <a id="home-link" href="../index.html"><img id="site-icon" src="../icon.png" alt="Gaming Philosophy Class icon"></a>
   </nav>
   <header id="page-header" data-default-course="introPhilosophy">Course • Activity</header>
   <div class="container">

--- a/trivia/trivia.html
+++ b/trivia/trivia.html
@@ -9,7 +9,7 @@
 </head>
 <body>
   <nav id="top-nav">
-    <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
+    <a id="home-link" href="../index.html"><img id="site-icon" src="../icon.png" alt="Gaming Philosophy Class icon"></a>
   </nav>
   <header id="page-header" data-default-course="introPhilosophy">Course • Activity</header>
   <div class="container">

--- a/trolley/trolley.html
+++ b/trolley/trolley.html
@@ -18,7 +18,7 @@
 </head>
 <body>
   <nav id="top-nav">
-    <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
+    <a id="home-link" href="../index.html"><img id="site-icon" src="../icon.png" alt="Gaming Philosophy Class icon"></a>
   </nav>
   <header id="page-header" data-default-course="ethics">Course • Activity</header>
   <div class="container">

--- a/writing/ai-evaluation.html
+++ b/writing/ai-evaluation.html
@@ -9,7 +9,7 @@
 </head>
 <body>
   <nav id="top-nav">
-    <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
+    <a id="home-link" href="../index.html"><img id="site-icon" src="../icon.png" alt="Gaming Philosophy Class icon"></a>
   </nav>
   <header id="page-header" data-default-course="writing">Course • Activity</header>
   <div class="container">

--- a/writing/brainstorm.html
+++ b/writing/brainstorm.html
@@ -94,7 +94,7 @@
 </head>
 <body>
   <nav id="top-nav">
-    <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
+    <a id="home-link" href="../index.html"><img id="site-icon" src="../icon.png" alt="Gaming Philosophy Class icon"></a>
   </nav>
   <header id="page-header" data-default-course="writing">Course • Activity</header>
   <div class="container">

--- a/writing/citation-aid.html
+++ b/writing/citation-aid.html
@@ -9,7 +9,7 @@
 </head>
 <body>
   <nav id="top-nav">
-    <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
+    <a id="home-link" href="../index.html"><img id="site-icon" src="../icon.png" alt="Gaming Philosophy Class icon"></a>
   </nav>
   <header id="page-header" data-default-course="writing">Course • Activity</header>
   <div class="container">

--- a/writing/citation.html
+++ b/writing/citation.html
@@ -9,7 +9,7 @@
 </head>
 <body>
   <nav id="top-nav">
-    <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
+    <a id="home-link" href="../index.html"><img id="site-icon" src="../icon.png" alt="Gaming Philosophy Class icon"></a>
   </nav>
   <header id="page-header" data-default-course="writing">Course • Activity</header>
   <div class="container">

--- a/writing/draft-development.html
+++ b/writing/draft-development.html
@@ -24,7 +24,7 @@
 </head>
 <body>
   <nav id="top-nav">
-    <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
+    <a id="home-link" href="../index.html"><img id="site-icon" src="../icon.png" alt="Gaming Philosophy Class icon"></a>
   </nav>
   <header id="page-header" data-default-course="writing">Course • Activity</header>
   <div class="container">

--- a/writing/index.html
+++ b/writing/index.html
@@ -9,7 +9,7 @@
 </head>
 <body>
   <nav id="top-nav">
-    <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
+    <a id="home-link" href="../index.html"><img id="site-icon" src="../icon.png" alt="Gaming Philosophy Class icon"></a>
   </nav>
   <header id="page-header" data-default-course="writing">Course • Activity</header>
   <div class="container">

--- a/writing/outline-worksheet.html
+++ b/writing/outline-worksheet.html
@@ -9,7 +9,7 @@
 </head>
 <body>
   <nav id="top-nav">
-    <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
+    <a id="home-link" href="../index.html"><img id="site-icon" src="../icon.png" alt="Gaming Philosophy Class icon"></a>
   </nav>
   <header id="page-header" data-default-course="writing">Course • Activity</header>
   <div class="container">

--- a/writing/outlining.html
+++ b/writing/outlining.html
@@ -55,7 +55,7 @@
 </head>
 <body>
   <nav id="top-nav">
-    <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
+    <a id="home-link" href="../index.html"><img id="site-icon" src="../icon.png" alt="Gaming Philosophy Class icon"></a>
   </nav>
   <header id="page-header" data-default-course="writing">Course • Activity</header>
   <div class="container">

--- a/writing/peer-review.html
+++ b/writing/peer-review.html
@@ -9,7 +9,7 @@
 </head>
 <body>
   <nav id="top-nav">
-    <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
+    <a id="home-link" href="../index.html"><img id="site-icon" src="../icon.png" alt="Gaming Philosophy Class icon"></a>
   </nav>
   <header id="page-header" data-default-course="writing">Course • Activity</header>
   <div class="container">

--- a/writing/thesis-evaluation.html
+++ b/writing/thesis-evaluation.html
@@ -9,7 +9,7 @@
 </head>
 <body>
   <nav id="top-nav">
-    <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
+    <a id="home-link" href="../index.html"><img id="site-icon" src="../icon.png" alt="Gaming Philosophy Class icon"></a>
   </nav>
   <header id="page-header" data-default-course="writing">Course • Activity</header>
   <div class="container">

--- a/writing/writing.html
+++ b/writing/writing.html
@@ -9,7 +9,7 @@
 </head>
 <body>
   <nav id="top-nav">
-    <a id="home-link" href="../index.html">Gaming Philosophy Class</a>
+    <a id="home-link" href="../index.html"><img id="site-icon" src="../icon.png" alt="Gaming Philosophy Class icon"></a>
   </nav>
   <header id="page-header" data-default-course="writing">Course • Activity</header>
   <div class="container">


### PR DESCRIPTION
## Summary
- swap the "Gaming Philosophy Class" header text for the icon linking home
- keep the homepage header unchanged
- remove extra space left by the text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a11e071d08322bec5430123112143