### PR TITLE
Hide topic selector during review games

### DIFF
--- a/jeopardy/index.html
+++ b/jeopardy/index.html
@@ -4,6 +4,14 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Φ interactive</title>
+  <script>
+    (function() {
+      const p = new URLSearchParams(window.location.search);
+      if (p.get('topic') && p.get('exam')) {
+        document.documentElement.classList.add('review');
+      }
+    })();
+  </script>
   <link rel="stylesheet" href="style.css">
   <link rel="icon" href="../favicon.png" type="image/png">
 </head>

--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -147,6 +147,12 @@ body.home {
   color: #e0e0e0;
 }
 
+html.review #instructions,
+html.review #topic-selector,
+html.review #quote-sidebar {
+  display: none;
+}
+
 #topic-selector {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- auto-apply a `review` class when the Jeopardy page is opened with `topic` and `exam` parameters
- hide the topic selector, instructions, and quote sidebar when the `review` class is present

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_685a173a1f548322905c36485ca45238