### PR TITLE
Color-coded exam buttons

### DIFF
--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -264,6 +264,22 @@ body.home .course[data-course="writing"] a.button:hover {
   margin-top: 4px;
 }
 
+/* Match exam buttons to course colors */
+body.home #topic-selector .course[data-course="criticalThinking"] .exam-dropdown button {
+  background-color: #f44336;
+  color: #fff;
+}
+body.home #topic-selector .course[data-course="criticalThinking"] .exam-dropdown button:hover {
+  background-color: #d32f2f;
+}
+body.home #topic-selector .course[data-course="ethics"] .exam-dropdown button {
+  background-color: #2196f3;
+  color: #fff;
+}
+body.home #topic-selector .course[data-course="ethics"] .exam-dropdown button:hover {
+  background-color: #1976d2;
+}
+
 .game-links {
   display: flex;
   gap: 6px;


### PR DESCRIPTION
## Summary
- adjust exam dropdown button colors for specific courses
- increase selector specificity so course colors override defaults

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_685a17a04ddc83229a0884cb5f063605