### PR TITLE
Remove extra icon from review page

### DIFF
--- a/jeopardy/index.html
+++ b/jeopardy/index.html
@@ -22,7 +22,6 @@
   <header id="page-header" data-default-course="introPhilosophy">Course • Activity</header>
 
   <main class="container">
-    <a href="../index.html"><img id="site-icon" src="../icon.png" alt="Φ interactive icon"></a>
     <p id="instructions">Pick a course to explore flashcards, trivia, and a game board. Play solo or with friends.</p>
     <div id="topic-selector">
       <div class="course">


### PR DESCRIPTION
## Summary
- remove unused small site icon from Jeopardy review page

## Testing
- `git show -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_685a1f724d1883229c8c86e95f1661ae