### PR TITLE
Add topic selector CSS for exam buttons

### DIFF
--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -271,18 +271,22 @@ body.home .course[data-course="writing"] a.button:hover {
 }
 
 /* Match exam buttons to course colors */
-body.home .course[data-course="criticalThinking"] .exam-dropdown button {
+body.home .course[data-course="criticalThinking"] .exam-dropdown button,
+#topic-selector .course[data-course="criticalThinking"] .exam-dropdown button {
   background-color: #f44336;
   color: #fff;
 }
-body.home .course[data-course="criticalThinking"] .exam-dropdown button:hover {
+body.home .course[data-course="criticalThinking"] .exam-dropdown button:hover,
+#topic-selector .course[data-course="criticalThinking"] .exam-dropdown button:hover {
   background-color: #d32f2f;
 }
-body.home .course[data-course="ethics"] .exam-dropdown button {
+body.home .course[data-course="ethics"] .exam-dropdown button,
+#topic-selector .course[data-course="ethics"] .exam-dropdown button {
   background-color: #2196f3;
   color: #fff;
 }
-body.home .course[data-course="ethics"] .exam-dropdown button:hover {
+body.home .course[data-course="ethics"] .exam-dropdown button:hover,
+#topic-selector .course[data-course="ethics"] .exam-dropdown button:hover {
   background-color: #1976d2;
 }
 


### PR DESCRIPTION
## Summary
- scope exam-dropdown button colors within #topic-selector so course colors apply on Jeopardy page
- keep existing `body.home` rules for homepage compatibility

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a21f4b94c8322a9939ec75338cd85