### PR TITLE
Improve homepage onboarding and navigation

### DIFF
--- a/chatbots/ethics-chat.html
+++ b/chatbots/ethics-chat.html
@@ -14,6 +14,7 @@
   <header id="page-header" data-default-course="ethics">Course • Activity</header>
   <div class="container">
     <h1>Moral Theorists Group Chat</h1>
+    <p class="instructions">Discuss dilemmas with famous ethicists in a rotating conversation.</p>
     <div id="chat-box"></div>
     <div id="chat-controls"></div>
   </div>

--- a/chatbots/intro-philosophy-chat.html
+++ b/chatbots/intro-philosophy-chat.html
@@ -14,6 +14,7 @@
   <header id="page-header" data-default-course="introPhilosophy">Course • Activity</header>
   <div class="container">
     <h1>Ancient Greek Philosophy Chat</h1>
+    <p class="instructions">Chat with early thinkers to explore classic ideas.</p>
     <div id="chat-box"></div>
     <div id="chat-controls"></div>
   </div>

--- a/flashcards/flashcards.html
+++ b/flashcards/flashcards.html
@@ -15,6 +15,7 @@
   <header id="page-header" data-default-course="introPhilosophy">Course • Activity</header>
   <div class="container">
     <h1>Flashcards</h1>
+    <p class="instructions">Review key terms using simple flip cards.</p>
     <div>
       <label for="category-select">Topic:</label>
       <select id="category-select" disabled>

--- a/index.html
+++ b/index.html
@@ -17,8 +17,9 @@
 
   <main class="container home-container">
     <div id="topic-selector">
-      <div class="course" data-course="introPhilosophy">
+      <div class="course" id="introPhilosophy" data-course="introPhilosophy">
         <h3>Intro to Philosophy</h3>
+        <p class="course-desc">Survey major thinkers from Plato to Nietzsche.</p>
         <div class="game-links">
           <a class="button" href="argument-reconstruction/intro-philosophy.html?course=introPhilosophy" title="Arguments – Reconstruct basic arguments">Arguments</a>
           <a class="button" href="flashcards/flashcards.html?course=introPhilosophy" title="Flashcards – Study key terms">Flashcards</a>
@@ -33,8 +34,9 @@
         </div>
         <div class="course-progress"><div class="course-progress-bar"></div></div>
       </div>
-      <div class="course" data-course="criticalThinking">
+      <div class="course" id="criticalThinking" data-course="criticalThinking">
         <h3>Critical Thinking</h3>
+        <p class="course-desc">Sharpen logic and reasoning through games.</p>
         <div class="game-links">
           <a class="button" href="argument-reconstruction/critical-thinking.html?course=criticalThinking" title="Arguments – Practice logical analysis">Arguments</a>
           <a class="button" href="flashcards/flashcards.html?course=criticalThinking" title="Flashcards – Review logic terms">Flashcards</a>
@@ -49,8 +51,9 @@
         </div>
         <div class="course-progress"><div class="course-progress-bar"></div></div>
       </div>
-      <div class="course" data-course="ethics">
+      <div class="course" id="ethics" data-course="ethics">
         <h3>Ethics</h3>
+        <p class="course-desc">Examine moral theories and difficult dilemmas.</p>
         <div class="game-links">
           <a class="button" href="argument-reconstruction/ethics.html?course=ethics" title="Arguments – Evaluate moral reasoning">Arguments</a>
           <a class="button" href="flashcards/flashcards.html?course=ethics" title="Flashcards – Study ethical theories">Flashcards</a>
@@ -65,8 +68,9 @@
         </div>
         <div class="course-progress"><div class="course-progress-bar"></div></div>
       </div>
-      <div class="course" data-course="writing">
+      <div class="course" id="writing" data-course="writing">
         <h3>Writing in Philosophy</h3>
+        <p class="course-desc">Practice outlining, drafting and peer feedback.</p>
         <div class="game-links">
           <a class="button" href="writing/citation.html?course=writing" title="Citation Activity – Spot citation errors">Citation Activity</a>
           <a class="button" href="writing/brainstorm.html?course=writing" title="Mind Mapping – Generate ideas visually">Mind Mapping</a>
@@ -89,11 +93,19 @@
         <button id="quote-next" class="hidden" hidden title="Next quote">Next Quote</button>
       </div>
     </div>
+    <div id="tour-modal" class="hidden" hidden>
+      <div class="modal-content">
+        <p id="tour-text"></p>
+        <button id="tour-next">Next</button>
+      </div>
+    </div>
   </main>
 
   <footer class="site-footer">&copy; <a href="https://www.maparks.com">maxaeon</a> 2025</footer>
   <script src="utils.js"></script>
   <script src="home-review.js"></script>
   <script src="jeopardy/who-said-it.js"></script>
+  <script src="tour.js"></script>
+  <script src="page-header.js"></script>
 </body>
 </html>

--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -484,6 +484,64 @@ button {
   transition: width 0.3s ease;
 }
 
+.course-desc {
+  margin: 4px 0 10px;
+  font-size: 14px;
+  color: #ccc;
+}
+
+#course-sidebar {
+  position: fixed;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  background: #1e1e1e;
+  border-right: 2px solid #7b1fa2;
+  padding: 10px;
+  width: 200px;
+  z-index: 1000;
+  transition: transform 0.3s;
+}
+
+#course-sidebar.collapsed {
+  transform: translate(-100%, -50%);
+}
+
+@media (min-width: 768px) {
+  #course-sidebar {
+    bottom: 0;
+    top: auto;
+    transform: none;
+  }
+
+  #course-sidebar.collapsed {
+    transform: translateX(-100%);
+  }
+}
+
+#course-toggle {
+  position: absolute;
+  right: -32px;
+  top: 10px;
+  background: #9c27b0;
+  color: #ffeb3b;
+  border: none;
+  border-radius: 0 6px 6px 0;
+  padding: 6px;
+  cursor: pointer;
+}
+
+#course-sidebar nav {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+#course-sidebar a {
+  color: #ffeb3b;
+  text-decoration: none;
+}
+
 #quote-sidebar {
   position: fixed;
   right: 0;

--- a/page-header.js
+++ b/page-header.js
@@ -25,6 +25,26 @@ function loadHelpModal() {
     });
 }
 
+function createCourseSidebar() {
+  const sidebar = document.createElement('div');
+  sidebar.id = 'course-sidebar';
+  sidebar.classList.add('collapsed');
+  const base = document.currentScript.src.substring(0, document.currentScript.src.lastIndexOf('/'));
+  const home = base + '/index.html';
+  sidebar.innerHTML = `
+    <button id="course-toggle" aria-label="Toggle course links">\u276E</button>
+    <nav>
+      <a href="${home}#introPhilosophy">Intro</a>
+      <a href="${home}#criticalThinking">Critical</a>
+      <a href="${home}#ethics">Ethics</a>
+    </nav>`;
+  document.body.appendChild(sidebar);
+  const toggle = sidebar.querySelector('#course-toggle');
+  if (toggle) toggle.addEventListener('click', () => {
+    sidebar.classList.toggle('collapsed');
+  });
+}
+
 function updatePageHeader(courseKey) {
   const header = document.getElementById('page-header');
   if (!header) return;
@@ -56,4 +76,5 @@ window.addEventListener('DOMContentLoaded', () => {
   updatePageHeader(courseKey);
 
   loadHelpModal();
+  createCourseSidebar();
 });

--- a/timeline/timeline.html
+++ b/timeline/timeline.html
@@ -35,6 +35,7 @@
   <header id="page-header" data-default-course="introPhilosophy">Course • Activity</header>
   <div class="container">
     <h1>Interactive Timeline</h1>
+    <p class="instructions">Browse philosophers chronologically using the navigation buttons.</p>
     <div id="timeline-entry" tabindex="0">
       <h2 id="philosopher-name"></h2>
       <h3 id="philosopher-era"></h3>

--- a/tour.js
+++ b/tour.js
@@ -1,0 +1,39 @@
+const steps = [
+  'Welcome! Select any course to see its activities.',
+  'Use the sidebar to quickly jump between courses.',
+  'Each activity includes a short description of what you\'ll do.'
+];
+let stepIndex = 0;
+function showStep() {
+  const text = document.getElementById('tour-text');
+  const btn = document.getElementById('tour-next');
+  if (!text || !btn) return;
+  text.textContent = steps[stepIndex];
+  btn.textContent = stepIndex === steps.length - 1 ? 'Done' : 'Next';
+}
+function endTour() {
+  const modal = document.getElementById('tour-modal');
+  if (modal) {
+    modal.classList.add('hidden');
+    modal.hidden = true;
+    localStorage.setItem('tour-complete', '1');
+  }
+}
+document.addEventListener('DOMContentLoaded', () => {
+  const modal = document.getElementById('tour-modal');
+  const btn = document.getElementById('tour-next');
+  if (!modal || !btn) return;
+  if (!localStorage.getItem('tour-complete')) {
+    modal.classList.remove('hidden');
+    modal.hidden = false;
+    showStep();
+  }
+  btn.addEventListener('click', () => {
+    stepIndex++;
+    if (stepIndex >= steps.length) {
+      endTour();
+    } else {
+      showStep();
+    }
+  });
+});

--- a/trivia/trivia.html
+++ b/trivia/trivia.html
@@ -14,6 +14,7 @@
   <header id="page-header" data-default-course="introPhilosophy">Course • Activity</header>
   <div class="container">
     <h1>Trivia Game</h1>
+    <p class="instructions">Answer multiple-choice questions to test yourself.</p>
     <div>
       <label for="category-select">Topic:</label>
       <select id="category-select" disabled>

--- a/trolley/trolley.html
+++ b/trolley/trolley.html
@@ -23,6 +23,7 @@
   <header id="page-header" data-default-course="ethics">Course • Activity</header>
   <div class="container">
     <h1>Trolley Problem Simulator</h1>
+    <p class="instructions">Make split-second choices in classic moral dilemmas.</p>
     <div id="scenario">
       <p id="scenario-text"></p>
       <div class="game-links" id="choices">

--- a/writing/index.html
+++ b/writing/index.html
@@ -14,6 +14,7 @@
   <header id="page-header" data-default-course="writing">Course • Activity</header>
   <div class="container">
     <h1>Writing Games</h1>
+    <p class="instructions">Explore activities that build philosophical writing skills.</p>
     <div class="game-links">
       <button onclick="location.href='citation.html'">Citation Activity</button>
       <button onclick="location.href='citation-aid.html'">Citation Guide</button>

--- a/writing/outline-worksheet.html
+++ b/writing/outline-worksheet.html
@@ -14,6 +14,7 @@
   <header id="page-header" data-default-course="writing">Course • Activity</header>
   <div class="container">
     <h1>Outline Worksheet</h1>
+    <p class="instructions">Use this worksheet to craft a clear essay outline.</p>
     <button id="example-btn">Show Example Outline</button>
     <div id="hint-text" class="hidden" hidden></div>
     <label>Thesis Statement:</label><br>


### PR DESCRIPTION
## Summary
- add brief onboarding tour to homepage
- provide quick sidebar for jumping between courses
- clarify homepage and activity pages with short descriptions

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685a288995dc83229854bdffaf01e908