### PR TITLE
Fix inaccurate philosophy chat tooltip

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
           <a class="button" href="argument-reconstruction/intro-philosophy.html?course=introPhilosophy" title="Arguments – Reconstruct basic arguments">Arguments</a>
           <a class="button" href="flashcards/flashcards.html?course=introPhilosophy" title="Flashcards – Study key terms">Flashcards</a>
           <a class="button" href="trivia/trivia.html?course=introPhilosophy" title="Trivia – Quick knowledge quiz">Trivia</a>
-          <a class="button" href="chatbots/intro-philosophy-chat.html?course=introPhilosophy" title="Chat – Talk with Kant, Mill, Aristotle…">Chat</a>
+          <a class="button" href="chatbots/intro-philosophy-chat.html?course=introPhilosophy" title="Chat – Talk with ancient Greek philosophers">Chat</a>
           <a class="button" href="timeline/timeline.html?course=introPhilosophy" title="Timeline – Explore philosophers by date">Timeline</a>
           <a class="button review-btn" href="#" title="Exam Review – Choose a midterm or final game">Review Games</a>
           <div class="exam-dropdown hidden" hidden>

--- a/jeopardy/index.html
+++ b/jeopardy/index.html
@@ -29,7 +29,7 @@
         <div class="game-links">
           <button onclick="location.href='../flashcards/flashcards.html?course=introPhilosophy'" title="Flashcards – Study key terms">Flashcards</button>
           <button onclick="location.href='../trivia/trivia.html?course=introPhilosophy'" title="Trivia – Quick knowledge quiz">Trivia</button>
-          <button onclick="location.href='../chatbots/intro-philosophy-chat.html'" title="Chat – Talk with Kant, Mill, Aristotle…">Chat</button>
+          <button onclick="location.href='../chatbots/intro-philosophy-chat.html'" title="Chat – Talk with ancient Greek philosophers">Chat</button>
         </div>
         <button class="topic-btn" data-topic="introPhilosophy" title="Game Board – Play Jeopardy-style questions">Game Board</button>
         <div class="exam-dropdown hidden" hidden>


### PR DESCRIPTION
## Summary
- update the tooltip text for the Intro to Philosophy chat link on the home page
- update the same tooltip text in Jeopardy page links

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685a30f328888322bcf8445e6f45ebb3