### PR TITLE
Rename citation activity references

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Additional pages include:
 - `argument-reconstruction/intro-philosophy.html` – analyze classic philosophical arguments
 - `chatbots/ethics-chat.html` – lightweight rotating chat with famous ethicists
 - `chatbots/intro-philosophy-chat.html` – interactive chat with ancient Greek philosophers
-- `writing/citation.html` – citation activity focused on MLA style
+- `writing/citation.html` – citation practice focused on MLA style
 - `writing/brainstorm.html` – build mind-map clusters for brainstorming
 - `writing/outlining.html` – outline builder for critiquing moral absolutism
 - `writing/thesis-evaluation.html` – evaluate and revise a thesis draft

--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
         <h3>Writing in Philosophy</h3>
         <p class="course-desc">Practice outlining, drafting and peer feedback.</p>
         <div class="game-links">
-          <a class="button" href="writing/citation.html?course=writing" title="Citation Activity – Spot citation errors">Citation Activity</a>
+          <a class="button" href="writing/citation.html?course=writing" title="Citation Practice – Spot citation errors">Citation Practice</a>
           <a class="button" href="writing/brainstorm.html?course=writing" title="Mind Mapping – Generate ideas visually">Mind Mapping</a>
           <a class="button" href="writing/outlining.html?course=writing" title="Outline Builder – Organize your essay">Outline Builder</a>
           <a class="button" href="writing/thesis-evaluation.html?course=writing" title="Thesis Evaluation – Rate possible theses">Thesis Evaluation</a>

--- a/writing/citation-aid.html
+++ b/writing/citation-aid.html
@@ -14,7 +14,7 @@
   <header id="page-header" data-default-course="writing">Course • Activity</header>
   <div class="container">
     <h1>Citation Guide</h1>
-    <p class="instructions">Consult this quick reference after completing the citation activity. The examples here follow MLA style, though other styles may suit different disciplines.</p>
+    <p class="instructions">Consult this quick reference after completing the citation practice. The examples here follow MLA style, though other styles may suit different disciplines.</p>
     <section>
       <h2>In-Text Citation Basics</h2>
       <p>Include the author's last name and page number in parentheses: <code>(Kant 31)</code>.</p>
@@ -59,7 +59,7 @@ Aristotle argues virtue is a mean (<em>Nicomachean Ethics</em> 1107b).
         <li>Free citation managers such as <a href="https://www.zotero.org" target="_blank">Zotero</a>, <a href="https://www.mendeley.com" target="_blank">Mendeley</a>, and <a href="https://endnote.com" target="_blank">EndNote</a> help organize references.</li>
         <li>Use the "Cite" or "Export" option on <a href="https://scholar.google.com" target="_blank">Google Scholar</a> or your library's website to download citations to these tools or copy formatted entries.</li>
       </ul>
-      <button onclick="location.href='citation.html'">Return to Citation Activity</button>
+      <button onclick="location.href='citation.html'">Return to Citation Practice</button>
     </section>
   </div>
   <script src="../page-header.js"></script>

--- a/writing/citation.html
+++ b/writing/citation.html
@@ -13,7 +13,7 @@
   </nav>
   <header id="page-header" data-default-course="writing">Course • Activity</header>
   <div class="container">
-    <h1>Citation Activity</h1>
+    <h1>Citation Practice</h1>
     <p class="instructions">Accurate citations help readers locate your sources, strengthen your credibility, and prevent plagiarism. Philosophical writing relies heavily on accurate referencing. This activity practices MLA in-text and Works Cited formatting. Other citation styles may be preferred in different contexts, so always follow your assignment guidelines.</p>
     <div id="citation-game">
       <p id="citation-prompt"></p>

--- a/writing/index.html
+++ b/writing/index.html
@@ -16,7 +16,7 @@
     <h1>Writing Games</h1>
     <p class="instructions">Explore activities that build philosophical writing skills.</p>
     <div class="game-links">
-      <button onclick="location.href='citation.html'">Citation Activity</button>
+      <button onclick="location.href='citation.html'">Citation Practice</button>
       <button onclick="location.href='citation-aid.html'">Citation Guide</button>
       <button onclick="location.href='brainstorm.html'">Mind Mapping</button>
       <button onclick="location.href='outlining.html'">Outline Builder</button>

--- a/writing/writing.html
+++ b/writing/writing.html
@@ -17,7 +17,7 @@
     <p>Practice key stages of philosophical writing through short activities. Each section includes instructions and examples labeled as "example provided" for comparison.</p>
 
     <section id="citation">
-      <h2>1. Citation Activity</h2>
+      <h2>1. Citation Practice</h2>
       <p>Identify and correct the citation mistakes in the passage. This activity practices MLA style; other styles may be required elsewhere.</p>
       <p id="citation-prompt"></p>
       <textarea id="citation-input" rows="3" style="width:90%;"></textarea><br>


### PR DESCRIPTION
## Summary
- rename the writing link in the home page
- update writing index page links
- rename the heading in citation.html
- adjust citation guide wording and button text
- rename the citation exercise heading in writing.html
- update README entry

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685a33d4812c832291c02813d981ff7c