### PR TITLE
Add Source Savvy link and explain popups

### DIFF
--- a/explain.js
+++ b/explain.js
@@ -1,0 +1,103 @@
+const explainData = {
+  "Categorical Imperative": [
+    "The Categorical Imperative clearly states that you must act only according to maxims (rules) you could consistently want everyone else to follow universally. For instance, lying is always wrong because universal dishonesty would undermine trust entirely.",
+    "The Means-End Formulation of Kant’s Categorical Imperative explicitly instructs us to treat humanity—ourselves and others—always as ends in themselves, never merely as means. This means explicitly respecting people’s dignity and autonomy, rather than using them as tools for our own purposes."
+  ],
+  "Consequentialism": [
+    "Consequentialism explicitly states that the morality of an action depends entirely on its consequences. Good actions are those that clearly produce the best overall outcomes, such as maximum happiness.",
+    "Utilitarianism, the best-known form of consequentialism, explicitly defines moral rightness by the Greatest Happiness Principle: an action is morally right if it produces the greatest amount of happiness for the greatest number of people."
+  ],
+  "Deontology": [
+    "Deontology is an ethical framework that clearly emphasizes duties and moral rules. Unlike consequentialism, deontology explicitly argues that some actions (like lying or harming innocents) are inherently wrong regardless of outcomes. Kant’s categorical imperative is a primary example of deontology."
+  ],
+  "Virtue Ethics": [
+    "Virtue Ethics explicitly emphasizes developing good character traits—virtues like courage, honesty, and generosity. Morality is clearly about cultivating these virtues and exercising practical wisdom.",
+    "Aristotle explicitly argues that virtue is a balanced, moderate state between extremes (excess and deficiency). For example, courage is the clear midpoint between recklessness and cowardice. Virtuous behavior explicitly requires moderation and balance."
+  ],
+  "Philosophical Bullshit": [
+    "Philosopher Harry Frankfurt explicitly defines 'bullshit' as statements made without any genuine concern for truth or accuracy—often intended simply to impress or sound meaningful without real substance. Philosophical writing requires clearly avoiding such meaningless or empty language and instead demands precise, truthful, and verifiable statements."
+  ],
+  "Environmental Impact of AI": [
+    "Artificial Intelligence (AI) technologies, especially large-scale models, explicitly require significant amounts of energy and computing resources to train and operate. This results in substantial carbon emissions and environmental impact. Responsible use of AI clearly involves balancing convenience and efficiency with awareness of its environmental footprint."
+  ],
+  "Fact Verification": [
+    "Fact verification explicitly involves checking the accuracy and truthfulness of claims, statements, or references against reliable, authoritative sources. This skill is critical in academic and philosophical writing to avoid misinformation and to ensure credibility. Always verify explicitly by consulting credible sources, original texts, or reputable experts."
+  ],
+  "Eudaimonia": [
+    "Eudaimonia is an ancient Greek term explicitly translated as happiness, flourishing, or human well-being. Aristotle explicitly describes eudaimonia as the highest goal of human life, achieved through the active pursuit of virtue, rational thought, and practical wisdom (phronesis). It means living a fulfilling life, not just experiencing temporary pleasure."
+  ],
+  "Practical Wisdom": [
+    "Practical wisdom, or phronesis, explicitly refers to the ability to make good judgments and choose appropriate actions based on experience, reason, and virtue. Aristotle emphasizes practical wisdom as essential for effectively navigating complex ethical situations, clearly guiding us to act morally and wisely in everyday life."
+  ],
+  "Natural Law": [
+    "Natural Law explicitly refers to the idea that moral principles are rooted in human nature itself and discoverable by reason. Philosopher Thomas Aquinas clearly argues natural law provides universal standards for morality, derived from rational understanding of human purposes. It often serves explicitly as the basis for arguments about human rights and justice."
+  ],
+  "Dualism": [
+    "Dualism explicitly claims reality consists of two fundamentally different kinds of substances: physical (material) and mental (immaterial)."
+  ],
+  "Materialism": [
+    "Materialism explicitly states that everything that exists, including minds and consciousness, is purely physical matter and its interactions."
+  ],
+  "Deductive Argument": [
+    "A deductive argument explicitly aims to provide logically conclusive support for its conclusion. If the premises are true, the conclusion must clearly be true.",
+    "A deductive argument is clearly valid if the conclusion follows logically from the premises. If an argument is both valid and explicitly has true premises, it is sound—guaranteeing a true conclusion."
+  ],
+  "Inductive Argument": [
+    "An inductive argument explicitly provides probable (but not guaranteed) support for its conclusion, based on evidence or examples.",
+    "An inductive argument is clearly strong if the premises make the conclusion highly probable. If a strong argument explicitly has true premises, it is cogent—indicating a likely, but not guaranteed, true conclusion."
+  ],
+  "Logical Fallacy": [
+    "A logical fallacy explicitly refers to a mistake in reasoning or argumentation that weakens or invalidates an argument.",
+    "The Ad Hominem fallacy explicitly occurs when someone attacks the character or traits of the person making the argument, rather than addressing the argument itself, which clearly fails to logically challenge the argument itself."
+  ]
+};
+
+function attachExplainHandlers() {
+  document.querySelectorAll('.explain-term').forEach(el => {
+    el.addEventListener('click', () => showExplanation(el.dataset.term));
+  });
+}
+
+function showExplanation(term) {
+  const texts = explainData[term];
+  if (!texts) return;
+  const overlay = document.createElement('div');
+  overlay.className = 'explain-overlay';
+  const popup = document.createElement('div');
+  popup.className = 'explain-popup';
+  const close = document.createElement('button');
+  close.className = 'explain-close';
+  close.textContent = 'X';
+  const text = document.createElement('div');
+  text.className = 'explain-text';
+  text.textContent = texts[0];
+  const controls = document.createElement('div');
+  controls.className = 'explain-version';
+  if (texts.length > 1) {
+    texts.forEach((_, idx) => {
+      const span = document.createElement('span');
+      span.textContent = `${idx + 1}/${texts.length}`;
+      span.className = 'version-btn' + (idx === 0 ? ' active' : '');
+      span.dataset.index = idx;
+      controls.appendChild(span);
+    });
+    controls.addEventListener('click', e => {
+      if (e.target.classList.contains('version-btn')) {
+        const i = parseInt(e.target.dataset.index, 10);
+        text.textContent = texts[i];
+        controls.querySelectorAll('.version-btn').forEach(btn => btn.classList.remove('active'));
+        e.target.classList.add('active');
+      }
+    });
+  }
+  close.onclick = () => overlay.remove();
+  popup.appendChild(close);
+  popup.appendChild(text);
+  if (texts.length > 1) popup.appendChild(controls);
+  overlay.appendChild(popup);
+  document.body.appendChild(overlay);
+}
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('DOMContentLoaded', attachExplainHandlers);
+}

--- a/index.html
+++ b/index.html
@@ -72,7 +72,7 @@
         <h3>Writing in Philosophy</h3>
         <p class="course-desc">Practice outlining, drafting and peer feedback.</p>
         <div class="game-links">
-          <a class="button" href="writing/citation.html?course=writing" title="Citation Practice – Spot citation errors">Citation Practice</a>
+          <a class="button" href="writing/citation.html?course=writing" title="Source Savvy – Spot citation errors">Source Savvy</a>
           <a class="button" href="writing/brainstorm.html?course=writing" title="Mind Mapping – Generate ideas visually">Mind Mapping</a>
           <a class="button" href="writing/outlining.html?course=writing" title="Outline Builder – Organize your essay">Outline Builder</a>
           <a class="button" href="writing/thesis-evaluation.html?course=writing" title="Thesis Evaluation – Rate possible theses">Thesis Evaluation</a>
@@ -83,7 +83,28 @@
         <div class="course-progress"><div class="course-progress-bar"></div></div>
       </div>
     </div>
-    <div id="quote-sidebar" class="quote-open">
+      <section id="key-terms">
+        <h2>Key Terms</h2>
+        <p>Click any <em><strong>italicized term</strong></em> to learn more.</p>
+        <ul class="explain-list">
+          <li><span class="explain-term" data-term="Categorical Imperative"><em><strong>Categorical Imperative</strong></em></span></li>
+          <li><span class="explain-term" data-term="Consequentialism"><em><strong>Consequentialism</strong></em></span></li>
+          <li><span class="explain-term" data-term="Deontology"><em><strong>Deontology</strong></em></span></li>
+          <li><span class="explain-term" data-term="Virtue Ethics"><em><strong>Virtue Ethics</strong></em></span></li>
+          <li><span class="explain-term" data-term="Philosophical Bullshit"><em><strong>Philosophical Bullshit</strong></em></span></li>
+          <li><span class="explain-term" data-term="Environmental Impact of AI"><em><strong>Environmental Impact of AI</strong></em></span></li>
+          <li><span class="explain-term" data-term="Fact Verification"><em><strong>Fact Verification</strong></em></span></li>
+          <li><span class="explain-term" data-term="Eudaimonia"><em><strong>Eudaimonia</strong></em></span></li>
+          <li><span class="explain-term" data-term="Practical Wisdom"><em><strong>Practical Wisdom</strong></em></span></li>
+          <li><span class="explain-term" data-term="Natural Law"><em><strong>Natural Law</strong></em></span></li>
+          <li><span class="explain-term" data-term="Dualism"><em><strong>Dualism</strong></em></span></li>
+          <li><span class="explain-term" data-term="Materialism"><em><strong>Materialism</strong></em></span></li>
+          <li><span class="explain-term" data-term="Deductive Argument"><em><strong>Deductive Argument</strong></em></span></li>
+          <li><span class="explain-term" data-term="Inductive Argument"><em><strong>Inductive Argument</strong></em></span></li>
+          <li><span class="explain-term" data-term="Logical Fallacy"><em><strong>Logical Fallacy</strong></em></span></li>
+        </ul>
+      </section>
+      <div id="quote-sidebar" class="quote-open">
       <button id="quote-toggle" aria-label="Toggle Who Said It" title="Toggle the quote game">&#x276E;</button>
       <div id="quote-game">
         <h2>Who said it?</h2>
@@ -107,5 +128,6 @@
   <script src="jeopardy/who-said-it.js"></script>
   <script src="tour.js"></script>
   <script src="page-header.js"></script>
+  <script src="explain.js"></script>
 </body>
 </html>

--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -1072,3 +1072,64 @@ button {
   }
 }
 
+.explain-term {
+  font-style: italic;
+  font-weight: bold;
+  cursor: pointer;
+  border-bottom: 1px dotted #7b1fa2;
+}
+
+.explain-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 2000;
+}
+
+.explain-popup {
+  background: #1e1e1e;
+  color: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  max-width: 500px;
+  width: 90%;
+  position: relative;
+}
+
+.explain-close {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: none;
+  color: #fff;
+  border: none;
+  font-size: 20px;
+  cursor: pointer;
+}
+
+.explain-version {
+  position: absolute;
+  bottom: 8px;
+  right: 8px;
+}
+
+.explain-version .version-btn {
+  margin-left: 6px;
+  cursor: pointer;
+}
+
+.explain-version .version-btn.active {
+  text-decoration: underline;
+}
+
+.explain-list {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  justify-content: center;
+}

--- a/writing/citation-aid.html
+++ b/writing/citation-aid.html
@@ -59,7 +59,7 @@ Aristotle argues virtue is a mean (<em>Nicomachean Ethics</em> 1107b).
         <li>Free citation managers such as <a href="https://www.zotero.org" target="_blank">Zotero</a>, <a href="https://www.mendeley.com" target="_blank">Mendeley</a>, and <a href="https://endnote.com" target="_blank">EndNote</a> help organize references.</li>
         <li>Use the "Cite" or "Export" option on <a href="https://scholar.google.com" target="_blank">Google Scholar</a> or your library's website to download citations to these tools or copy formatted entries.</li>
       </ul>
-      <button onclick="location.href='citation.html'">Return to Citation Practice</button>
+      <button onclick="location.href='citation.html'">Return to Source Savvy</button>
     </section>
   </div>
   <script src="../page-header.js"></script>

--- a/writing/citation.html
+++ b/writing/citation.html
@@ -30,7 +30,7 @@
     </section>
     <div id="verify-complete" class="hidden" hidden>
       <p>Great work verifying these claims. Fact-checking ensures your writing is accurate. Next, practice proper citations.</p>
-      <button id="verify-proceed">Continue to Citation Practice</button>
+      <button id="verify-proceed">Continue to Source Savvy</button>
     </div>
     <div id="verify-modal" class="hidden" hidden>
       <div class="modal-content" id="verify-modal-content"></div>

--- a/writing/index.html
+++ b/writing/index.html
@@ -16,7 +16,7 @@
     <h1>Writing Games</h1>
     <p class="instructions">Explore activities that build philosophical writing skills.</p>
     <div class="game-links">
-      <button onclick="location.href='citation.html'">Citation Practice</button>
+      <button onclick="location.href='citation.html'">Source Savvy</button>
       <button onclick="location.href='citation-aid.html'">Citation Guide</button>
       <button onclick="location.href='brainstorm.html'">Mind Mapping</button>
       <button onclick="location.href='outlining.html'">Outline Builder</button>

--- a/writing/writing.html
+++ b/writing/writing.html
@@ -17,7 +17,7 @@
     <p>Practice key stages of philosophical writing through short activities. Each section includes instructions and examples labeled as "example provided" for comparison.</p>
 
     <section id="citation">
-      <h2>1. Citation Practice</h2>
+      <h2>1. Source Savvy</h2>
       <p>Identify and correct the citation mistakes in the passage. This activity practices MLA style; other styles may be required elsewhere.</p>
       <p id="citation-prompt"></p>
       <textarea id="citation-input" rows="3" style="width:90%;"></textarea><br>


### PR DESCRIPTION
## Summary
- rename Citation Practice to Source Savvy across pages
- create interactive "Explain It To Me" popups with new `explain.js`
- style and add key term list on the home page

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685aa870dbb08322a9edeb4ebcc4ddc9