### PR TITLE
Add key term sidebars

### DIFF
--- a/argument-reconstruction/critical-thinking.html
+++ b/argument-reconstruction/critical-thinking.html
@@ -42,6 +42,8 @@
   <script src="../utils.js"></script>
   <script src="critical-thinking.js"></script>
   <script src="../next-activity.js"></script>
+  <script src="../explain.js"></script>
+  <script src="../keyterms-sidebar.js"></script>
   <script src="../page-header.js"></script>
 </body>
 </html>

--- a/argument-reconstruction/ethics.html
+++ b/argument-reconstruction/ethics.html
@@ -43,6 +43,8 @@
   <script src="../utils.js"></script>
   <script src="ethics.js"></script>
   <script src="../next-activity.js"></script>
+  <script src="../explain.js"></script>
+  <script src="../keyterms-sidebar.js"></script>
   <script src="../page-header.js"></script>
 </body>
 </html>

--- a/argument-reconstruction/intro-philosophy.html
+++ b/argument-reconstruction/intro-philosophy.html
@@ -42,6 +42,8 @@
   <script src="../utils.js"></script>
   <script src="intro-philosophy.js"></script>
   <script src="../next-activity.js"></script>
+  <script src="../explain.js"></script>
+  <script src="../keyterms-sidebar.js"></script>
   <script src="../page-header.js"></script>
 </body>
 </html>

--- a/chatbots/ethics-chat.html
+++ b/chatbots/ethics-chat.html
@@ -20,6 +20,8 @@
   </div>
   <script src="ethical-chatbot.js"></script>
   <script src="ethics-chat-engine.js"></script>
+  <script src="../explain.js"></script>
+  <script src="../keyterms-sidebar.js"></script>
   <script src="../page-header.js"></script>
 </body>
 </html>

--- a/chatbots/intro-philosophy-chat.html
+++ b/chatbots/intro-philosophy-chat.html
@@ -19,6 +19,8 @@
     <div id="chat-controls"></div>
   </div>
   <script src="intro-philosophy-chatbot-revised.js"></script>
+  <script src="../explain.js"></script>
+  <script src="../keyterms-sidebar.js"></script>
   <script src="../page-header.js"></script>
 </body>
 </html>

--- a/debate-duel/debate-duel.html
+++ b/debate-duel/debate-duel.html
@@ -59,6 +59,8 @@
   <script src="debate-duel.js"></script>
   <script src="../vendor/jspdf.umd.min.js"></script>
   <script src="../next-activity.js"></script>
+  <script src="../explain.js"></script>
+  <script src="../keyterms-sidebar.js"></script>
   <script src="../page-header.js"></script>
 </body>
 </html>

--- a/flashcards/flashcards.html
+++ b/flashcards/flashcards.html
@@ -52,6 +52,8 @@
   <script src="../jeopardy/data/ethics-flashcards.js"></script>
   <script src="../utils.js"></script>
   <script src="flashcards.js"></script>
+  <script src="../explain.js"></script>
+  <script src="../keyterms-sidebar.js"></script>
   <script src="../page-header.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -83,27 +83,6 @@
         <div class="course-progress"><div class="course-progress-bar"></div></div>
       </div>
     </div>
-      <section id="key-terms">
-        <h2>Key Terms</h2>
-        <p>Click any <em><strong>italicized term</strong></em> to learn more.</p>
-        <ul class="explain-list">
-          <li><span class="explain-term" data-term="Categorical Imperative"><em><strong>Categorical Imperative</strong></em></span></li>
-          <li><span class="explain-term" data-term="Consequentialism"><em><strong>Consequentialism</strong></em></span></li>
-          <li><span class="explain-term" data-term="Deontology"><em><strong>Deontology</strong></em></span></li>
-          <li><span class="explain-term" data-term="Virtue Ethics"><em><strong>Virtue Ethics</strong></em></span></li>
-          <li><span class="explain-term" data-term="Philosophical Bullshit"><em><strong>Philosophical Bullshit</strong></em></span></li>
-          <li><span class="explain-term" data-term="Environmental Impact of AI"><em><strong>Environmental Impact of AI</strong></em></span></li>
-          <li><span class="explain-term" data-term="Fact Verification"><em><strong>Fact Verification</strong></em></span></li>
-          <li><span class="explain-term" data-term="Eudaimonia"><em><strong>Eudaimonia</strong></em></span></li>
-          <li><span class="explain-term" data-term="Practical Wisdom"><em><strong>Practical Wisdom</strong></em></span></li>
-          <li><span class="explain-term" data-term="Natural Law"><em><strong>Natural Law</strong></em></span></li>
-          <li><span class="explain-term" data-term="Dualism"><em><strong>Dualism</strong></em></span></li>
-          <li><span class="explain-term" data-term="Materialism"><em><strong>Materialism</strong></em></span></li>
-          <li><span class="explain-term" data-term="Deductive Argument"><em><strong>Deductive Argument</strong></em></span></li>
-          <li><span class="explain-term" data-term="Inductive Argument"><em><strong>Inductive Argument</strong></em></span></li>
-          <li><span class="explain-term" data-term="Logical Fallacy"><em><strong>Logical Fallacy</strong></em></span></li>
-        </ul>
-      </section>
       <div id="quote-sidebar" class="quote-open">
       <button id="quote-toggle" aria-label="Toggle Who Said It" title="Toggle the quote game">&#x276E;</button>
       <div id="quote-game">

--- a/jeopardy/index.html
+++ b/jeopardy/index.html
@@ -149,6 +149,8 @@
   <script src="script.js"></script>
   <script src="inline-select.js"></script>
   <script src="who-said-it.js"></script>
+  <script src="../explain.js"></script>
+  <script src="../keyterms-sidebar.js"></script>
   <script src="../page-header.js"></script>
 </body>
 </html>

--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -556,7 +556,27 @@ button {
   transition: transform 0.3s;
 }
 
+#keyterm-sidebar {
+  position: fixed;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  background: #1e1e1e;
+  border-left: 2px solid #009688;
+  padding: 10px;
+  width: 260px;
+  max-width: 80vw;
+  max-height: 60vh;
+  overflow-y: auto;
+  z-index: 1000;
+  transition: transform 0.3s;
+}
+
 #quote-sidebar.collapsed {
+  transform: translate(100%, -50%);
+}
+
+#keyterm-sidebar.collapsed {
   transform: translate(100%, -50%);
 }
 
@@ -577,6 +597,18 @@ button {
   left: -32px;
   top: 10px;
   background: #9c27b0;
+  color: #ffeb3b;
+  border: none;
+  border-radius: 6px 0 0 6px;
+  padding: 6px;
+  cursor: pointer;
+}
+
+#keyterm-toggle {
+  position: absolute;
+  left: -32px;
+  top: 10px;
+  background: #009688;
   color: #ffeb3b;
   border: none;
   border-radius: 6px 0 0 6px;
@@ -1132,4 +1164,10 @@ button {
   flex-wrap: wrap;
   gap: 10px;
   justify-content: center;
+}
+
+#keyterm-content .explain-list {
+  flex-direction: column;
+  flex-wrap: nowrap;
+  align-items: flex-start;
 }

--- a/keyterms-sidebar.js
+++ b/keyterms-sidebar.js
@@ -1,0 +1,48 @@
+function createKeyTermsSidebar(courseKey) {
+  if (document.body.classList.contains('home')) return;
+  const termMap = {
+    introPhilosophy: [
+      'Dualism',
+      'Materialism',
+      'Natural Law'
+    ],
+    criticalThinking: [
+      'Deductive Argument',
+      'Inductive Argument',
+      'Logical Fallacy',
+      'Fact Verification'
+    ],
+    ethics: [
+      'Categorical Imperative',
+      'Consequentialism',
+      'Deontology',
+      'Virtue Ethics',
+      'Eudaimonia',
+      'Practical Wisdom',
+      'Philosophical Bullshit',
+      'Environmental Impact of AI'
+    ]
+  };
+  const terms = termMap[courseKey];
+  if (!terms) return;
+  const sidebar = document.createElement('div');
+  sidebar.id = 'keyterm-sidebar';
+  sidebar.classList.add('collapsed');
+  sidebar.innerHTML = `<button id="keyterm-toggle" aria-label="Toggle Key Terms">\u276E</button>` +
+    `<div id="keyterm-content"><h2>Key Terms</h2><ul class="explain-list">` +
+    terms.map(t => `<li><span class="explain-term" data-term="${t}"><em><strong>${t}</strong></em></span></li>`).join('') +
+    `</ul></div>`;
+  document.body.appendChild(sidebar);
+  const toggle = sidebar.querySelector('#keyterm-toggle');
+  toggle.addEventListener('click', () => {
+    const collapsed = sidebar.classList.toggle('collapsed');
+    toggle.innerHTML = collapsed ? '\u276E' : '\u276F';
+  });
+  if (typeof attachExplainHandlers === 'function') {
+    attachExplainHandlers();
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.createKeyTermsSidebar = createKeyTermsSidebar;
+}

--- a/page-header.js
+++ b/page-header.js
@@ -77,4 +77,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
   loadHelpModal();
   createCourseSidebar();
+  if (typeof createKeyTermsSidebar === 'function') {
+    createKeyTermsSidebar(courseKey);
+  }
 });

--- a/sherlock-mystery/sherlock.html
+++ b/sherlock-mystery/sherlock.html
@@ -36,6 +36,8 @@
     <div id="resolution-section" class="hidden" hidden></div>
   </div>
   <script src="sherlock.js"></script>
+  <script src="../explain.js"></script>
+  <script src="../keyterms-sidebar.js"></script>
   <script src="../page-header.js"></script>
 </body>
 </html>

--- a/timeline/timeline.html
+++ b/timeline/timeline.html
@@ -65,6 +65,8 @@
   </div>
   <script src="../utils.js"></script>
   <script src="timeline.js"></script>
+  <script src="../explain.js"></script>
+  <script src="../keyterms-sidebar.js"></script>
   <script src="../page-header.js"></script>
 </body>
 </html>

--- a/trivia/trivia.html
+++ b/trivia/trivia.html
@@ -47,6 +47,8 @@
   <script src="../utils.js"></script>
   <script src="trivia.js"></script>
   <script src="../next-activity.js"></script>
+  <script src="../explain.js"></script>
+  <script src="../keyterms-sidebar.js"></script>
   <script src="../page-header.js"></script>
 </body>
 </html>

--- a/trolley/trolley.html
+++ b/trolley/trolley.html
@@ -40,6 +40,8 @@
   </div>
   <script src="trolley.js"></script>
   <script src="../next-activity.js"></script>
+  <script src="../explain.js"></script>
+  <script src="../keyterms-sidebar.js"></script>
   <script src="../page-header.js"></script>
 </body>
 </html>

--- a/writing/ai-evaluation.html
+++ b/writing/ai-evaluation.html
@@ -81,6 +81,8 @@
     </section>
   </div>
   <script src="ai-evaluation.js"></script>
+  <script src="../explain.js"></script>
+  <script src="../keyterms-sidebar.js"></script>
   <script src="../page-header.js"></script>
 </body>
 </html>

--- a/writing/brainstorm.html
+++ b/writing/brainstorm.html
@@ -120,6 +120,8 @@
   <script src="brainstorm.js"></script>
   <script src="../vendor/html2canvas.min.js"></script>
   <script src="../vendor/jspdf.umd.min.js"></script>
+  <script src="../explain.js"></script>
+  <script src="../keyterms-sidebar.js"></script>
   <script src="../page-header.js"></script>
 </body>
 </html>

--- a/writing/citation-aid.html
+++ b/writing/citation-aid.html
@@ -62,6 +62,8 @@ Aristotle argues virtue is a mean (<em>Nicomachean Ethics</em> 1107b).
       <button onclick="location.href='citation.html'">Return to Source Savvy</button>
     </section>
   </div>
+  <script src="../explain.js"></script>
+  <script src="../keyterms-sidebar.js"></script>
   <script src="../page-header.js"></script>
 </body>
 </html>

--- a/writing/citation.html
+++ b/writing/citation.html
@@ -97,6 +97,8 @@ Kant writes that one must never lie (31).
     </section>
   </div>
   <script src="citation.js"></script>
+  <script src="../explain.js"></script>
+  <script src="../keyterms-sidebar.js"></script>
   <script src="../page-header.js"></script>
 </body>
 </html>

--- a/writing/draft-development.html
+++ b/writing/draft-development.html
@@ -121,6 +121,8 @@
   </div>
   <script src="draft-development.js"></script>
   <script src="../vendor/jspdf.umd.min.js"></script>
+  <script src="../explain.js"></script>
+  <script src="../keyterms-sidebar.js"></script>
   <script src="../page-header.js"></script>
 </body>
 </html>

--- a/writing/index.html
+++ b/writing/index.html
@@ -26,6 +26,8 @@
       <button onclick="location.href='ai-evaluation.html'">Bullshit Detector</button>
     </div>
   </div>
+  <script src="../explain.js"></script>
+  <script src="../keyterms-sidebar.js"></script>
   <script src="../page-header.js"></script>
 </body>
 </html>

--- a/writing/outline-worksheet.html
+++ b/writing/outline-worksheet.html
@@ -50,6 +50,8 @@
   </div>
   <script src="outline-worksheet.js"></script>
   <script src="../vendor/jspdf.umd.min.js"></script>
+  <script src="../explain.js"></script>
+  <script src="../keyterms-sidebar.js"></script>
   <script src="../page-header.js"></script>
 </body>
 </html>

--- a/writing/outlining.html
+++ b/writing/outlining.html
@@ -73,6 +73,8 @@
   </div>
   <script src="../utils.js"></script>
   <script src="outlining.js"></script>
+  <script src="../explain.js"></script>
+  <script src="../keyterms-sidebar.js"></script>
   <script src="../page-header.js"></script>
 </body>
 </html>

--- a/writing/peer-review.html
+++ b/writing/peer-review.html
@@ -68,6 +68,8 @@
   </div>
   <script src="peer-review.js"></script>
   <script src="../vendor/jspdf.umd.min.js"></script>
+  <script src="../explain.js"></script>
+  <script src="../keyterms-sidebar.js"></script>
   <script src="../page-header.js"></script>
 </body>
 </html>

--- a/writing/thesis-evaluation.html
+++ b/writing/thesis-evaluation.html
@@ -59,6 +59,8 @@
   </div>
   <script src="thesis-evaluation.js"></script>
   <script src="../vendor/docx.umd.min.js"></script>
+  <script src="../explain.js"></script>
+  <script src="../keyterms-sidebar.js"></script>
   <script src="../page-header.js"></script>
 </body>
 </html>

--- a/writing/writing.html
+++ b/writing/writing.html
@@ -115,6 +115,8 @@
 
   <script src="writing.js"></script>
   <script src="../vendor/jspdf.umd.min.js"></script>
+  <script src="../explain.js"></script>
+  <script src="../keyterms-sidebar.js"></script>
   <script src="../page-header.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add collapsible key term sidebar with per-course terms
- remove old key terms list from the home page
- include the sidebar on all activity pages
- style key term sidebar in main stylesheet

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685ad37f565c8322bc742237160e25bc