### PR TITLE
Add Logic course option

### DIFF
--- a/flashcards/flashcards.js
+++ b/flashcards/flashcards.js
@@ -7,7 +7,7 @@ function mergeSets(target, source) {
 }
 
 function buildFlashcards() {
-  const courses = ['introPhilosophy', 'criticalThinking', 'ethics'];
+  const courses = ['introPhilosophy', 'criticalThinking', 'ethics', 'logic'];
   const flashcards = {};
 
   courses.forEach(course => {
@@ -31,6 +31,7 @@ const courseColors = {
   introPhilosophy: '#9c27b0',
   criticalThinking: '#f44336',
   ethics: '#2196f3',
+  logic: '#ffeb3b',
   writing: '#424242'
 };
 let currentCards = [];

--- a/index.html
+++ b/index.html
@@ -68,6 +68,17 @@
         </div>
         <div class="course-progress"><div class="course-progress-bar"></div></div>
       </div>
+      <div class="course" id="logic" data-course="logic">
+        <h3>Logic</h3>
+        <p class="course-desc">Master symbolic reasoning and puzzle solving.</p>
+        <div class="game-links">
+          <a class="button" href="argument-reconstruction/critical-thinking.html?course=logic" title="Arguments – Practice formal proofs">Arguments</a>
+          <a class="button" href="flashcards/flashcards.html?course=logic" title="Flashcards – Study logical concepts">Flashcards</a>
+          <a class="button" href="trivia/trivia.html?course=logic" title="Trivia – Quick logic quiz">Trivia</a>
+          <a class="button" href="sherlock-mystery/sherlock.html?course=logic" title="Logic Puzzles – Solve mysteries">Logic Puzzles</a>
+        </div>
+        <div class="course-progress"><div class="course-progress-bar"></div></div>
+      </div>
       <div class="course" id="writing" data-course="writing">
         <h3>Writing in Philosophy</h3>
         <p class="course-desc">Practice outlining, drafting and peer feedback.</p>

--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -236,6 +236,25 @@ body.home .course[data-course="ethics"] a.button:hover {
   background-color: #1976d2;
 }
 
+body.home .course[data-course="logic"] {
+  background: #000;
+  border-color: #ffeb3b;
+}
+
+body.home .course[data-course="logic"] h3 {
+  color: #ffeb3b;
+}
+
+body.home .course[data-course="logic"] a.button {
+  background-color: #ffeb3b;
+  color: #000;
+}
+
+body.home .course[data-course="logic"] a.button:hover {
+  background-color: #fdd835;
+  color: #000;
+}
+
 body.home .course[data-course="writing"] {
   background: #222;
   border-color: #555;

--- a/next-activity.js
+++ b/next-activity.js
@@ -15,7 +15,8 @@ function showNextActivity(course) {
       label: 'Flashcards',
       url: '../flashcards/flashcards.html?course=criticalThinking'
     },
-    ethics: { label: 'Flashcards', url: '../flashcards/flashcards.html?course=ethics' }
+    ethics: { label: 'Flashcards', url: '../flashcards/flashcards.html?course=ethics' },
+    logic: { label: 'Flashcards', url: '../flashcards/flashcards.html?course=logic' }
   };
   const rec = map[course];
   const div = document.createElement('div');

--- a/page-header.js
+++ b/page-header.js
@@ -37,6 +37,7 @@ function createCourseSidebar() {
       <a href="${home}#introPhilosophy">Intro</a>
       <a href="${home}#criticalThinking">Critical</a>
       <a href="${home}#ethics">Ethics</a>
+      <a href="${home}#logic">Logic</a>
     </nav>`;
   document.body.appendChild(sidebar);
   const toggle = sidebar.querySelector('#course-toggle');
@@ -55,6 +56,7 @@ function updatePageHeader(courseKey) {
     introPhilosophy: 'Intro to Philosophy',
     criticalThinking: 'Critical Thinking',
     ethics: 'Ethics',
+    logic: 'Logic',
     writing: 'Writing'
   };
   const course = courseMap[courseKey] || (courseKey ? courseKey : 'Course');

--- a/trivia/trivia.js
+++ b/trivia/trivia.js
@@ -7,7 +7,7 @@ function mergeTrivia(target, source) {
 }
 
 function buildTriviaQuestions() {
-  const courses = ['introPhilosophy', 'criticalThinking', 'ethics'];
+  const courses = ['introPhilosophy', 'criticalThinking', 'ethics', 'logic'];
   const trivia = {};
 
   courses.forEach(course => {


### PR DESCRIPTION
## Summary
- add a Logic course section with links on the homepage
- style the Logic course with a yellow theme
- list Logic in the sidebar and page header map
- support Logic in next activity recommendations
- allow Flashcards and Trivia scripts to handle the Logic course

## Testing
- `node -c flashcards/flashcards.js`
- `node -c next-activity.js`
- `node -c page-header.js`
- `node -c trivia/trivia.js`

------
https://chatgpt.com/codex/tasks/task_e_685af5db11288322b1a40a7a038518c9