### PR TITLE
Add dedicated logic trivia set with custom feedback

### DIFF
--- a/jeopardy/data/logic.js
+++ b/jeopardy/data/logic.js
@@ -1,0 +1,164 @@
+window.logicQuestions = {
+  "General Logic & Arguments": [
+    {
+      question: "What part of an argument explicitly provides evidence or reason for a conclusion?",
+      answer: "B) Premise",
+      options: [
+        "A) Conclusion",
+        "B) Premise",
+        "C) Deduction",
+        "D) Induction"
+      ],
+      feedback: "Premises explicitly provide the support for a conclusion."
+    },
+    {
+      question: "An argument structured so if premises are true, the conclusion must be true is called:",
+      answer: "A) Valid",
+      options: [
+        "A) Valid",
+        "B) Strong",
+        "C) Cogent",
+        "D) Inductive"
+      ],
+      feedback: "This explicitly describes a valid deductive argument."
+    },
+    {
+      question: "If an argument has false premises but good logical form, it\u2019s called:",
+      answer: "B) Valid but Unsound",
+      options: [
+        "A) Valid and Sound",
+        "B) Valid but Unsound",
+        "C) Invalid",
+        "D) Strong and Cogent"
+      ],
+      feedback: "A valid argument with false premises is clearly unsound."
+    }
+  ],
+  "Categorical Logic": [
+    {
+      question: "Which categorical proposition states 'All S are P'?",
+      answer: "C) Universal Affirmative (A)",
+      options: [
+        "A) Particular Negative (O)",
+        "B) Particular Affirmative (I)",
+        "C) Universal Affirmative (A)",
+        "D) Universal Negative (E)"
+      ],
+      feedback: "The Universal Affirmative explicitly states 'All S are P.'"
+    },
+    {
+      question: "Which categorical proposition explicitly denies membership of one class to another completely?",
+      answer: "B) Universal Negative (E)",
+      options: [
+        "A) Universal Affirmative (A)",
+        "B) Universal Negative (E)",
+        "C) Particular Affirmative (I)",
+        "D) Particular Negative (O)"
+      ],
+      feedback: "'No S are P' explicitly expresses the Universal Negative."
+    },
+    {
+      question: "A categorical syllogism explicitly consists of:",
+      answer: "A) Two premises and one conclusion",
+      options: [
+        "A) Two premises and one conclusion",
+        "B) One premise and one conclusion",
+        "C) Three conclusions",
+        "D) Three premises"
+      ],
+      feedback: "A syllogism explicitly includes two premises and a conclusion."
+    }
+  ],
+  "Propositional Logic": [
+    {
+      question: "Which connective explicitly symbolizes 'and'?",
+      answer: "C) Conjunction (\u2227)",
+      options: [
+        "A) Disjunction (\u2228)",
+        "B) Negation (\u00ac)",
+        "C) Conjunction (\u2227)",
+        "D) Conditional (\u2192)"
+      ],
+      feedback: "The conjunction (\u2227) explicitly represents 'and.'"
+    },
+    {
+      question: "In propositional logic, a tautology is explicitly:",
+      answer: "B) Always true",
+      options: [
+        "A) Always false",
+        "B) Always true",
+        "C) True or false depending on conditions",
+        "D) Neither true nor false"
+      ],
+      feedback: "A tautology explicitly is always true."
+    },
+    {
+      question: "Which connective explicitly represents the conditional (if...then)?",
+      answer: "C) \u2192",
+      options: [
+        "A) \u2194",
+        "B) \u2228",
+        "C) \u2192",
+        "D) \u00ac"
+      ],
+      feedback: "The conditional is explicitly represented by '\u2192.'"
+    },
+    {
+      question: "A contradiction explicitly refers to a statement that:",
+      answer: "A) Is always false",
+      options: [
+        "A) Is always false",
+        "B) Is always true",
+        "C) Is true only sometimes",
+        "D) Cannot be evaluated"
+      ],
+      feedback: "A contradiction explicitly is always false."
+    }
+  ],
+  "Validity & Argument Forms": [
+    {
+      question: "'If P then Q; P; thus Q' explicitly represents which argument form?",
+      answer: "C) Modus Ponens",
+      options: [
+        "A) Modus Tollens",
+        "B) Hypothetical Syllogism",
+        "C) Modus Ponens",
+        "D) Disjunctive Syllogism"
+      ],
+      feedback: "Modus Ponens explicitly follows this structure."
+    },
+    {
+      question: "'If P then Q; Not Q; thus not P' explicitly represents:",
+      answer: "C) Modus Tollens",
+      options: [
+        "A) Modus Ponens",
+        "B) Hypothetical Syllogism",
+        "C) Modus Tollens",
+        "D) Disjunctive Syllogism"
+      ],
+      feedback: "This explicitly represents Modus Tollens."
+    },
+    {
+      question: "Which form is clearly invalid?",
+      answer: "A) Affirming the Consequent",
+      options: [
+        "A) Affirming the Consequent",
+        "B) Modus Ponens",
+        "C) Modus Tollens",
+        "D) Disjunctive Syllogism"
+      ],
+      feedback: "Affirming the Consequent explicitly is invalid."
+    },
+    {
+      question: "What logical error is explicitly made in the argument: 'If P then Q; not P; thus not Q'?",
+      answer: "B) Denying the Antecedent",
+      options: [
+        "A) Affirming the Consequent",
+        "B) Denying the Antecedent",
+        "C) Modus Tollens",
+        "D) Modus Ponens"
+      ],
+      feedback: "Denying the Antecedent explicitly makes this argument invalid."
+    }
+  ]
+};

--- a/trivia/trivia.html
+++ b/trivia/trivia.html
@@ -44,6 +44,7 @@
   <script src="../jeopardy/data/critical-thinking-final.js"></script>
   <script src="../jeopardy/data/intro-philosophy.js"></script>
   <script src="../jeopardy/data/intro-philosophy-final.js"></script>
+  <script src="../jeopardy/data/logic.js"></script>
   <script src="../utils.js"></script>
   <script src="trivia.js"></script>
   <script src="../next-activity.js"></script>

--- a/trivia/trivia.js
+++ b/trivia/trivia.js
@@ -92,11 +92,14 @@ function loadTrivia(course, category = 'all') {
   showTriviaQuestion();
 }
 
-function buildChoices(correct) {
+function buildChoices(question) {
+  if (question.options) {
+    return question.options.slice();
+  }
   const answers = currentTrivia.map(q => q.answer);
-  const others = answers.filter(a => a !== correct);
+  const others = answers.filter(a => a !== question.answer);
   shuffle(others);
-  const choices = others.slice(0, 3).concat(correct);
+  const choices = others.slice(0, 3).concat(question.answer);
   shuffle(choices);
   return choices;
 }
@@ -108,7 +111,7 @@ function showTriviaQuestion() {
   updateScore();
   const optionsDiv = document.getElementById('trivia-options');
   optionsDiv.innerHTML = '';
-  const choices = buildChoices(q.answer);
+  const choices = buildChoices(q);
   optionIndex = 0;
   choices.forEach((ans, idx) => {
     const btn = document.createElement('button');
@@ -126,11 +129,15 @@ function submitTrivia(choice) {
   const q = currentTrivia[triviaIndex];
   const feedback = document.getElementById('trivia-feedback');
   if (choice === q.answer) {
-    feedback.innerText = 'Correct!';
+    const msg = q.feedback ? `Correct! ${q.feedback}` : 'Correct!';
+    feedback.innerText = msg;
     feedback.style.color = '#4caf50';
     correctCount++;
   } else {
-    feedback.innerText = `Nope! The correct answer is ${q.answer}.`;
+    const msg = q.feedback
+      ? `Nope! The correct answer is ${q.answer}. ${q.feedback}`
+      : `Nope! The correct answer is ${q.answer}.`;
+    feedback.innerText = msg;
     feedback.style.color = '#c62828';
   }
   feedback.classList.remove('hidden');   feedback.hidden = false;


### PR DESCRIPTION
## Summary
- add script load for new logic questions
- support custom options and feedback in trivia game
- create logic question dataset with 14 questions across four categories

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685af86c73b48322b798a33d0a54bd0f