### PR TITLE
Add interactive truth tables activity

### DIFF
--- a/truth-tables/symbolization.html
+++ b/truth-tables/symbolization.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Φ interactive</title>
+  <link rel="stylesheet" href="../jeopardy/style.css">
+  <link rel="icon" href="../favicon.png" type="image/png">
+</head>
+<body>
+  <nav id="top-nav">
+    <a id="home-link" href="../index.html"><img id="site-icon" src="../icon.png" alt="Φ interactive icon"></a>
+  </nav>
+  <header id="page-header" data-default-course="logic">Course • Activity</header>
+  <div class="container">
+    <h1>Symbolization Basics</h1>
+    <p class="instructions">Review the main logical connectives and practice symbolizing statements.</p>
+
+    <h2>Connectives</h2>
+    <table class="truth-table">
+      <tr><th>P</th><th>¬P</th></tr>
+      <tr><td>T</td><td>F</td></tr>
+      <tr><td>F</td><td>T</td></tr>
+    </table>
+    <table class="truth-table">
+      <tr><th>P</th><th>Q</th><th>P ∧ Q</th></tr>
+      <tr><td>T</td><td>T</td><td>T</td></tr>
+      <tr><td>T</td><td>F</td><td>F</td></tr>
+      <tr><td>F</td><td>T</td><td>F</td></tr>
+      <tr><td>F</td><td>F</td><td>F</td></tr>
+    </table>
+    <table class="truth-table">
+      <tr><th>P</th><th>Q</th><th>P ∨ Q</th></tr>
+      <tr><td>T</td><td>T</td><td>T</td></tr>
+      <tr><td>T</td><td>F</td><td>T</td></tr>
+      <tr><td>F</td><td>T</td><td>T</td></tr>
+      <tr><td>F</td><td>F</td><td>F</td></tr>
+    </table>
+    <table class="truth-table">
+      <tr><th>P</th><th>Q</th><th>P → Q</th></tr>
+      <tr><td>T</td><td>T</td><td>T</td></tr>
+      <tr><td>T</td><td>F</td><td>F</td></tr>
+      <tr><td>F</td><td>T</td><td>T</td></tr>
+      <tr><td>F</td><td>F</td><td>T</td></tr>
+    </table>
+    <table class="truth-table">
+      <tr><th>P</th><th>Q</th><th>P ↔ Q</th></tr>
+      <tr><td>T</td><td>T</td><td>T</td></tr>
+      <tr><td>T</td><td>F</td><td>F</td></tr>
+      <tr><td>F</td><td>T</td><td>F</td></tr>
+      <tr><td>F</td><td>F</td><td>T</td></tr>
+    </table>
+
+    <h2>Symbolization Practice</h2>
+    <div class="symbolize mc-question" data-answer="R → W">
+      <p>If it rains, then the ground is wet.</p>
+      <div class="mc-options">
+        <button class="option-btn">R → W</button>
+        <button class="option-btn">R ∧ W</button>
+        <button class="option-btn">R ∨ W</button>
+      </div>
+      <div class="mc-feedback hidden" hidden></div>
+    </div>
+    <div class="symbolize mc-question" data-answer="S ∨ F">
+      <p>Either I study or I fail.</p>
+      <div class="mc-options">
+        <button class="option-btn">S ∧ F</button>
+        <button class="option-btn">S ∨ F</button>
+        <button class="option-btn">S → F</button>
+      </div>
+      <div class="mc-feedback hidden" hidden></div>
+    </div>
+    <div class="symbolize mc-question" data-answer="L ↔ U">
+      <p>The lamp is on if and only if the switch is up.</p>
+      <div class="mc-options">
+        <button class="option-btn">L ↔ U</button>
+        <button class="option-btn">L → U</button>
+        <button class="option-btn">U → L</button>
+      </div>
+      <div class="mc-feedback hidden" hidden></div>
+    </div>
+
+    <button id="start-tables">Continue to Truth Tables</button>
+  </div>
+  <script src="truth-tables.js"></script>
+  <script src="../next-activity.js"></script>
+  <script src="../page-header.js"></script>
+</body>
+</html>

--- a/truth-tables/truth-tables.html
+++ b/truth-tables/truth-tables.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Φ interactive</title>
+  <link rel="stylesheet" href="../jeopardy/style.css">
+  <link rel="icon" href="../favicon.png" type="image/png">
+</head>
+<body>
+  <nav id="top-nav">
+    <a id="home-link" href="../index.html"><img id="site-icon" src="../icon.png" alt="Φ interactive icon"></a>
+  </nav>
+  <header id="page-header" data-default-course="logic">Course • Activity</header>
+  <div class="container">
+    <h1>Truth Tables</h1>
+    <p class="instructions">Fill in each table by clicking cells to toggle T/F. Then check whether the statement is a tautology, contradiction, or contingent. The final table asks if the argument is valid.</p>
+
+    <div id="table-1" class="tt-section"></div>
+    <div id="table-2" class="tt-section"></div>
+    <div id="table-3" class="tt-section"></div>
+    <div id="validity" class="tt-section"></div>
+    <button id="back-symbolization">Back to Symbolization</button>
+  </div>
+  <script src="truth-tables.js"></script>
+  <script src="../next-activity.js"></script>
+  <script src="../page-header.js"></script>
+</body>
+</html>

--- a/truth-tables/truth-tables.js
+++ b/truth-tables/truth-tables.js
@@ -1,0 +1,194 @@
+function toggleCell(cell) {
+  if (cell.textContent === 'T') {
+    cell.textContent = 'F';
+  } else if (cell.textContent === 'F') {
+    cell.textContent = '';
+  } else {
+    cell.textContent = 'T';
+  }
+}
+
+function classify(values) {
+  const allTrue = values.every(v => v);
+  const allFalse = values.every(v => !v);
+  if (allTrue) return 'This statement is a tautology.';
+  if (allFalse) return 'This statement is a contradiction.';
+  return 'This statement is contingent.';
+}
+
+function buildTruthTable(containerId, vars, formulaLabel, compute) {
+  const container = document.getElementById(containerId);
+  const table = document.createElement('table');
+  table.className = 'truth-table';
+  const header = document.createElement('tr');
+  vars.forEach(v => {
+    const th = document.createElement('th');
+    th.textContent = v;
+    header.appendChild(th);
+  });
+  const resTh = document.createElement('th');
+  resTh.textContent = formulaLabel;
+  header.appendChild(resTh);
+  table.appendChild(header);
+  const rows = Math.pow(2, vars.length);
+  const cells = [];
+  for (let i = 0; i < rows; i++) {
+    const tr = document.createElement('tr');
+    const assignment = {};
+    vars.forEach((v, idx) => {
+      const bit = (i >> (vars.length - idx - 1)) & 1;
+      assignment[v] = !!bit;
+      const td = document.createElement('td');
+      td.textContent = bit ? 'T' : 'F';
+      tr.appendChild(td);
+    });
+    const td = document.createElement('td');
+    td.className = 'editable';
+    td.addEventListener('click', () => toggleCell(td));
+    tr.appendChild(td);
+    table.appendChild(tr);
+    cells.push({cell: td, assignment});
+  }
+  const btn = document.createElement('button');
+  btn.textContent = 'Check';
+  const fb = document.createElement('div');
+  fb.className = 'feedback hidden';
+  fb.hidden = true;
+  btn.addEventListener('click', () => {
+    let correct = true;
+    const results = [];
+    cells.forEach(({cell, assignment}) => {
+      const expected = compute(assignment);
+      const val = cell.textContent === 'T';
+      results.push(val);
+      if (val !== expected) correct = false;
+    });
+    fb.textContent = correct ? 'Correct! ' + classify(results) : 'Some values are incorrect.';
+    fb.style.color = correct ? '#4caf50' : '#c62828';
+    fb.classList.remove('hidden');
+    fb.hidden = false;
+    if (typeof showNextActivity === 'function' && correct && containerId === 'validity') {
+      showNextActivity(getCourse ? getCourse() : '');
+    }
+  });
+  container.appendChild(table);
+  container.appendChild(btn);
+  container.appendChild(fb);
+}
+
+function buildValidityTable(containerId, vars, premises, conclusion) {
+  const container = document.getElementById(containerId);
+  const table = document.createElement('table');
+  table.className = 'truth-table';
+  const header = document.createElement('tr');
+  vars.concat(premises.map(p => p.label)).concat([conclusion.label]).forEach(l => {
+    const th = document.createElement('th');
+    th.textContent = l;
+    header.appendChild(th);
+  });
+  table.appendChild(header);
+  const rows = Math.pow(2, vars.length);
+  const cells = [];
+  for (let i = 0; i < rows; i++) {
+    const tr = document.createElement('tr');
+    const assign = {};
+    vars.forEach((v, idx) => {
+      const bit = (i >> (vars.length - idx - 1)) & 1;
+      assign[v] = !!bit;
+      const td = document.createElement('td');
+      td.textContent = bit ? 'T' : 'F';
+      tr.appendChild(td);
+    });
+    premises.forEach(() => {
+      const td = document.createElement('td');
+      td.className = 'editable';
+      td.addEventListener('click', () => toggleCell(td));
+      tr.appendChild(td);
+      cells.push({type: 'premise', cell: td, assign});
+    });
+    const conclCell = document.createElement('td');
+    conclCell.className = 'editable';
+    conclCell.addEventListener('click', () => toggleCell(conclCell));
+    tr.appendChild(conclCell);
+    cells.push({type: 'conclusion', cell: conclCell, assign});
+    table.appendChild(tr);
+  }
+  const btn = document.createElement('button');
+  btn.textContent = 'Check';
+  const fb = document.createElement('div');
+  fb.className = 'feedback hidden';
+  fb.hidden = true;
+  btn.addEventListener('click', () => {
+    let correct = true;
+    let valid = true;
+    let idx = 0;
+    for (let i = 0; i < rows; i++) {
+      const assignment = cells[idx].assign;
+      const premiseVals = premises.map(p => p.compute(assignment));
+      premiseVals.forEach(() => {
+        const val = cells[idx].cell.textContent === 'T';
+        if (val !== premiseVals.shift()) correct = false;
+        idx++;
+      });
+      const conclExpected = conclusion.compute(assignment);
+      const conclVal = cells[idx].cell.textContent === 'T';
+      if (conclVal !== conclExpected) correct = false;
+      if (premiseVals.every(v => v) && !conclVal) valid = false;
+      idx++;
+    }
+    const msg = correct ? (valid ? 'Correct! The argument is valid.' : 'Correct! The argument is invalid.') : 'Some values are incorrect.';
+    fb.textContent = msg;
+    fb.style.color = correct ? '#4caf50' : '#c62828';
+    fb.classList.remove('hidden');
+    fb.hidden = false;
+    if (correct) {
+      if (typeof showNextActivity === 'function') {
+        showNextActivity(getCourse ? getCourse() : '');
+      }
+    }
+  });
+  container.appendChild(table);
+  container.appendChild(btn);
+  container.appendChild(fb);
+}
+
+function setupSymbolization() {
+  document.querySelectorAll('.symbolize').forEach(div => {
+    const answer = div.dataset.answer;
+    const fb = div.querySelector('.mc-feedback');
+    div.querySelectorAll('.option-btn').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const correct = btn.textContent.trim() === answer;
+        fb.textContent = correct ? 'Correct!' : `Nope! The correct symbolization is ${answer}.`;
+        fb.style.color = correct ? '#4caf50' : '#c62828';
+        fb.classList.remove('hidden');
+        fb.hidden = false;
+        div.querySelectorAll('.option-btn').forEach(b => b.disabled = true);
+      });
+    });
+  });
+  const next = document.getElementById('start-tables');
+  if (next) next.addEventListener('click', () => {
+    window.location.href = 'truth-tables.html';
+  });
+}
+
+function setupTables() {
+  if (!document.getElementById('table-1')) return;
+  buildTruthTable('table-1', ['P'], 'P ∨ ¬P', a => a.P || !a.P);
+  buildTruthTable('table-2', ['P'], 'P ∧ ¬P', a => a.P && !a.P);
+  buildTruthTable('table-3', ['P','Q'], 'P → Q', a => !a.P || a.Q);
+  buildValidityTable('validity', ['P','Q'], [
+    {label: 'P → Q', compute: a => !a.P || a.Q},
+    {label: 'P', compute: a => a.P}
+  ], {label: 'Q', compute: a => a.Q});
+  const back = document.getElementById('back-symbolization');
+  if (back) back.addEventListener('click', () => {
+    window.location.href = 'symbolization.html';
+  });
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  setupSymbolization();
+  setupTables();
+});


### PR DESCRIPTION
## Summary
- add new `truth-tables/` folder with two activity pages
- basic symbolization review with multiple choice questions
- interactive truth tables that classify statements and test an argument
- shared script handles toggling cells and navigation

## Testing
- `node -v`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685afee57a8c832283e561ab14361bb6