### PR TITLE
Add Proof Lab derivation activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Additional pages include:
 - `writing/draft-development.html` – step-by-step draft development with export options
 - `writing/peer-review.html` – practice giving constructive peer feedback
 - `writing/writing.html` – combined quick-writing challenges
+- `prover/prover.html` – Proof Lab for practicing derivations
 
 
 ## Project Structure
@@ -65,6 +66,7 @@ Additional pages include:
  - **sherlock-mystery/** – detective logic exercises
 - **chatbots/** – lightweight chat pages
 - **writing/** – short activities for philosophical writing practice
+- **prover/** – interactive derivation practice
 
 ### Custom Flashcard Sets
 

--- a/index.html
+++ b/index.html
@@ -76,6 +76,7 @@
           <a class="button" href="flashcards/flashcards.html?course=logic" title="Flashcards – Study logical concepts">Flashcards</a>
           <a class="button" href="trivia/trivia.html?course=logic" title="Trivia – Quick logic quiz">Trivia</a>
           <a class="button" href="truth-tables/symbolization.html?course=logic" title="Truth Tables – Evaluate argument forms">Truth Tables</a>
+          <a class="button" href="prover/prover.html?course=logic" title="Proof Lab – Practice derivations">Proof Lab</a>
         </div>
         <div class="course-progress"><div class="course-progress-bar"></div></div>
       </div>

--- a/prover/prover.html
+++ b/prover/prover.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Φ interactive</title>
+  <link rel="stylesheet" href="../jeopardy/style.css">
+  <link rel="icon" href="../favicon.png" type="image/png">
+  <style>
+    .rule { margin-bottom: 10px; }
+    .rule button { margin-left: 8px; }
+  </style>
+</head>
+<body>
+  <nav id="top-nav">
+    <a id="home-link" href="../index.html"><img id="site-icon" src="../icon.png" alt="Φ interactive icon"></a>
+  </nav>
+  <header id="page-header" data-default-course="logic">Course • Activity</header>
+  <div class="container">
+    <h1>Proof Lab</h1>
+    <section id="part1">
+      <p>Logical derivations are structured proofs where each step follows logically from previous steps using inference rules.</p>
+      <div class="rule">Given: "If P then Q" (P→Q) and "P", you can conclude: <span id="mp" class="hidden" hidden>Q</span><button onclick="reveal('mp')">Reveal</button></div>
+      <div class="rule">Given: "If P then Q" (P→Q) and "¬Q", you can conclude: <span id="mt" class="hidden" hidden>¬P</span><button onclick="reveal('mt')">Reveal</button></div>
+      <div class="rule">Given: "P→Q" and "Q→R", you can conclude: <span id="hs" class="hidden" hidden>P→R</span><button onclick="reveal('hs')">Reveal</button></div>
+      <div class="rule">Given: "P∨Q" and "¬P", you can conclude: <span id="ds" class="hidden" hidden>Q</span><button onclick="reveal('ds')">Reveal</button></div>
+      <button id="start-examples">Start Proof Examples</button>
+    </section>
+    <section id="part2" class="hidden" hidden>
+      <div id="example-info"></div>
+      <div id="options" class="mc-options"></div>
+      <div id="example-feedback" class="hidden" hidden></div>
+      <button id="next-step" class="hidden" hidden>Next</button>
+    </section>
+    <section id="part3" class="hidden" hidden>
+      <h2>Beyond Propositional Logic</h2>
+      <p>Toggle each statement to see its symbolic form.</p>
+      <div class="rule">Everyone is mortal. <button onclick="toggleDisplay('forall')">Show</button> <span id="forall" class="hidden" hidden>∀x(Mx)</span></div>
+      <div class="rule">Someone is happy. <button onclick="toggleDisplay('exists')">Show</button> <span id="exists" class="hidden" hidden>∃x(Hx)</span></div>
+      <p>Modal Operators:</p>
+      <div class="rule">It rains. <button onclick="toggleDisplay('poss')">◇</button> <span id="poss" class="hidden" hidden>◇R (Possibly R)</span> <button onclick="toggleDisplay('nec')">□</button> <span id="nec" class="hidden" hidden>□R (Necessarily R)</span></div>
+    </section>
+    <div id="summary" class="hidden" hidden></div>
+  </div>
+  <script src="../utils.js"></script>
+  <script src="prover.js"></script>
+  <script src="../next-activity.js"></script>
+  <script src="../explain.js"></script>
+  <script src="../keyterms-sidebar.js"></script>
+  <script src="../page-header.js"></script>
+</body>
+</html>

--- a/prover/prover.js
+++ b/prover/prover.js
@@ -1,0 +1,148 @@
+const rules = ['Modus Ponens','Modus Tollens','Hypothetical Syllogism','Disjunctive Syllogism','Conjunction Elimination'];
+
+const examples = [
+  {
+    premises: [
+      '1. If it rains, the street is wet. (R→W)',
+      '2. It rains. (R)'
+    ],
+    conclusion: 'The street is wet. (W)',
+    steps: [
+      {prompt: 'Select the rule that derives W from R→W and R.', answer: 'Modus Ponens', feedback: 'Modus Ponens derives W from R→W and R.'}
+    ]
+  },
+  {
+    premises: [
+      '1. If the power is on, the lights work. (P→L)',
+      '2. If the lights work, the room is bright. (L→B)'
+    ],
+    conclusion: 'If the power is on, the room is bright. (P→B)',
+    steps: [
+      {prompt: 'Which rule combines P→L and L→B to derive P→B?', answer: 'Hypothetical Syllogism', feedback: 'Hypothetical Syllogism combines P→L and L→B.'}
+    ]
+  },
+  {
+    premises: [
+      '1. If the program compiles, there are no errors. (C→¬E)',
+      '2. Either the program compiles or it\'s buggy. (C∨B)',
+      '3. There are errors. (E)'
+    ],
+    conclusion: 'The program is buggy. (B)',
+    steps: [
+      {prompt: 'Which rule derives ¬C from C→¬E and E?', answer: 'Modus Tollens', feedback: 'Modus Tollens gives ¬C.'},
+      {prompt: 'Which rule derives B from C∨B and ¬C?', answer: 'Disjunctive Syllogism', feedback: 'Disjunctive Syllogism yields B.'}
+    ]
+  },
+  {
+    premises: [
+      '1. P→(Q→R)',
+      '2. P∧Q'
+    ],
+    conclusion: 'R',
+    steps: [
+      {prompt: 'Which rule extracts P and Q from P∧Q?', answer: 'Conjunction Elimination', feedback: 'Conjunction Elimination splits P∧Q.'},
+      {prompt: 'Which rule gives Q→R from P→(Q→R) and P?', answer: 'Modus Ponens', feedback: 'Using Modus Ponens yields Q→R.'},
+      {prompt: 'Which rule derives R from Q→R and Q?', answer: 'Modus Ponens', feedback: 'Modus Ponens derives R.'}
+    ]
+  }
+];
+
+let exIndex = 0;
+let stepIndex = 0;
+
+function reveal(id) {
+  const el = document.getElementById(id);
+  if (el) {
+    el.classList.remove('hidden');
+    el.hidden = false;
+  }
+}
+
+function toggleDisplay(id) {
+  const el = document.getElementById(id);
+  if (el) {
+    const hide = !el.classList.contains('hidden');
+    if (hide) {
+      el.classList.add('hidden');
+      el.hidden = true;
+    } else {
+      el.classList.remove('hidden');
+      el.hidden = false;
+    }
+  }
+}
+
+function startExamples() {
+  document.getElementById('part1').classList.add('hidden');
+  document.getElementById('part1').hidden = true;
+  document.getElementById('part2').classList.remove('hidden');
+  document.getElementById('part2').hidden = false;
+  exIndex = 0;
+  stepIndex = 0;
+  showStep();
+}
+
+document.getElementById('start-examples').addEventListener('click', startExamples);
+
+document.getElementById('next-step').addEventListener('click', () => {
+  stepIndex++;
+  if (stepIndex >= examples[exIndex].steps.length) {
+    exIndex++;
+    stepIndex = 0;
+    if (exIndex >= examples.length) {
+      startPart3();
+      return;
+    }
+  }
+  showStep();
+});
+
+function showStep() {
+  const ex = examples[exIndex];
+  const step = ex.steps[stepIndex];
+  const info = document.getElementById('example-info');
+  info.innerHTML = `<p><strong>Premises:</strong><br>${ex.premises.join('<br>')}<br><strong>Conclusion:</strong> ${ex.conclusion}</p><p>${step.prompt}</p>`;
+  const optsDiv = document.getElementById('options');
+  optsDiv.innerHTML = '';
+  rules.forEach(rule => {
+    const btn = document.createElement('button');
+    btn.className = 'option-btn';
+    btn.innerText = rule;
+    btn.addEventListener('click', () => checkRule(rule));
+    optsDiv.appendChild(btn);
+  });
+  document.getElementById('example-feedback').classList.add('hidden');
+  document.getElementById('example-feedback').hidden = true;
+  document.getElementById('next-step').classList.add('hidden');
+  document.getElementById('next-step').hidden = true;
+}
+
+function checkRule(choice) {
+  const step = examples[exIndex].steps[stepIndex];
+  const fb = document.getElementById('example-feedback');
+  if (choice === step.answer) {
+    fb.textContent = `Correct! ✅ ${step.feedback}`;
+    fb.style.color = '#4caf50';
+    document.getElementById('next-step').classList.remove('hidden');
+    document.getElementById('next-step').hidden = false;
+  } else {
+    fb.textContent = 'Incorrect.';
+    fb.style.color = '#c62828';
+  }
+  fb.classList.remove('hidden');
+  fb.hidden = false;
+}
+
+function startPart3() {
+  document.getElementById('part2').classList.add('hidden');
+  document.getElementById('part2').hidden = true;
+  document.getElementById('part3').classList.remove('hidden');
+  document.getElementById('part3').hidden = false;
+  if (typeof showNextActivity === 'function') {
+    showNextActivity('logic');
+  }
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  // no-op placeholder to ensure script runs after DOM ready
+});


### PR DESCRIPTION
## Summary
- introduce new Proof Lab derivation activity under `prover/`
- link Proof Lab from the Logic section of the homepage
- document Proof Lab in README

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685b0193e9888322bfc706e1d8661f1c