### PR TITLE
Add logic midterm and final review question sets

### DIFF
--- a/jeopardy/data/logic-final.js
+++ b/jeopardy/data/logic-final.js
@@ -1,0 +1,50 @@
+// Final review questions for the Logic course
+window.logicFinalQuestions = {
+  "Proof Techniques": [
+    { question: "Which rule infers Q from P and P → Q?", answer: "Modus Ponens.", points: 100 },
+    { question: "What proof strategy assumes a statement to derive it conditionally?", answer: "Conditional proof.", points: 200 },
+    { question: "What do we call proving a statement by deriving a contradiction from its negation?", answer: "Indirect proof (reductio ad absurdum).", points: 300 },
+    { question: "Which rule combines separate statements into P ∧ Q?", answer: "Conjunction introduction.", points: 400 },
+    { question: "Which rule derives Q from P ∧ Q?", answer: "Conjunction elimination.", points: 500 }
+  ],
+
+  "Complex Connectives": [
+    { question: "Symbolize 'P only if Q'.", answer: "P → Q.", points: 100 },
+    { question: "Which connective does '↔' represent?", answer: "Biconditional.", points: 200 },
+    { question: "When is a biconditional P ↔ Q true?", answer: "When P and Q have the same truth value.", points: 300 },
+    { question: "Translate 'Unless P, Q' into symbols.", answer: "¬P → Q.", points: 400 },
+    { question: "How is exclusive or expressed in symbols?", answer: "(P ∨ Q) ∧ ¬(P ∧ Q) or P ⊕ Q.", points: 500 }
+  ],
+
+  "Predicate Logic Basics": [
+    { question: "What symbol expresses 'for all'?", answer: "∀.", points: 100 },
+    { question: "What symbol expresses 'there exists'?", answer: "∃.", points: 200 },
+    { question: "Translate 'All cats are mammals' into predicate logic.", answer: "∀x (Cat(x) → Mammal(x)).", points: 300 },
+    { question: "Translate 'Some dogs bark' into predicate logic.", answer: "∃x (Dog(x) ∧ Bark(x)).", points: 400 },
+    { question: "In predicate logic, what is the domain?", answer: "The set of objects the variables range over.", points: 500 }
+  ],
+
+  "Quantifiers & Identity": [
+    { question: "Negate '∀x P(x)' using a quantifier.", answer: "∃x ¬P(x).", points: 100 },
+    { question: "Negate '∃x P(x)' using a quantifier.", answer: "∀x ¬P(x).", points: 200 },
+    { question: "What does '=' mean in predicate logic?", answer: "It asserts two names refer to the same object.", points: 300 },
+    { question: "Symbolize 'Only one P'.", answer: "∃x (P(x) ∧ ∀y (P(y) → y = x)).", points: 400 },
+    { question: "What quantifier order expresses 'Everyone loves someone'?", answer: "∀x ∃y Loves(x, y).", points: 500 }
+  ],
+
+  "Modal Logic": [
+    { question: "What does the modal operator '□' mean?", answer: "Necessarily.", points: 100 },
+    { question: "What does the modal operator '◇' mean?", answer: "Possibly.", points: 200 },
+    { question: "In modal logic, what is a possible world?", answer: "A complete way things might have been.", points: 300 },
+    { question: "What does '□P → P' express?", answer: "If necessarily P then P (axiom T).", points: 400 },
+    { question: "Translate 'It is possible that P'.", answer: "◇P.", points: 500 }
+  ],
+
+  "Advanced Inference": [
+    { question: "What does a conditional derivation from P leading to contradiction show?", answer: "¬P by indirect proof.", points: 100 },
+    { question: "Which rule eliminates an existential quantifier?", answer: "Existential instantiation.", points: 200 },
+    { question: "Which rule introduces a universal quantifier?", answer: "Universal generalization.", points: 300 },
+    { question: "What role does identity play in predicate proofs?", answer: "It allows substitution of identical terms.", points: 400 },
+    { question: "In modal logic, what does '◇□P' mean?", answer: "It is possible that necessarily P.", points: 500 }
+  ]
+};

--- a/jeopardy/data/logic-midterm.js
+++ b/jeopardy/data/logic-midterm.js
@@ -1,0 +1,42 @@
+// Midterm review questions for the Logic course
+window.logicMidtermQuestions = {
+  "Logic Basics": [
+    { question: "What is a premise in an argument?", answer: "A statement offered as support for a conclusion.", points: 100 },
+    { question: "Define a deductive argument.", answer: "An argument where the conclusion necessarily follows if the premises are true.", points: 200 },
+    { question: "What does it mean for an argument to be valid?", answer: "If the premises are true, the conclusion must be true.", points: 300 },
+    { question: "What is a sound argument?", answer: "A valid argument with all true premises.", points: 400 },
+    { question: "Can an invalid argument have a true conclusion?", answer: "Yes, but the conclusion is not guaranteed by the premises.", points: 500 }
+  ],
+
+  "Valid & Invalid Forms": [
+    { question: "State the form of Modus Ponens.", answer: "If P then Q; P; therefore Q.", points: 100 },
+    { question: "Which form is 'If P then Q; Not Q; therefore Not P'?", answer: "Modus Tollens.", points: 200 },
+    { question: "What invalid form is 'If P then Q; Q; therefore P'?", answer: "Affirming the Consequent.", points: 300 },
+    { question: "What invalid form is 'If P then Q; Not P; therefore Not Q'?", answer: "Denying the Antecedent.", points: 400 },
+    { question: "What form infers Q from 'P or Q' and 'Not P'?", answer: "Disjunctive Syllogism.", points: 500 }
+  ],
+
+  "Symbolization": [
+    { question: "Which symbol represents 'and'?", answer: "∧ (conjunction).", points: 100 },
+    { question: "How do you symbolize 'Either P or Q'?", answer: "P ∨ Q.", points: 200 },
+    { question: "What does the symbol '¬' represent?", answer: "Negation.", points: 300 },
+    { question: "Symbolize 'If P then Q'.", answer: "P → Q.", points: 400 },
+    { question: "Symbolize 'P if and only if Q'.", answer: "P ↔ Q.", points: 500 }
+  ],
+
+  "Truth Tables": [
+    { question: "How many rows does a truth table for two variables have?", answer: "Four rows.", points: 100 },
+    { question: "When is a conjunction P ∧ Q true?", answer: "Only when both P and Q are true.", points: 200 },
+    { question: "When is a conditional P → Q false?", answer: "When P is true and Q is false.", points: 300 },
+    { question: "What do we call a statement true on every row of its table?", answer: "A tautology.", points: 400 },
+    { question: "How can a truth table show two statements are equivalent?", answer: "They share the same truth value on every row.", points: 500 }
+  ],
+
+  "Evaluating Arguments": [
+    { question: "How can a truth table show an argument is valid?", answer: "Every row making the premises true also makes the conclusion true.", points: 100 },
+    { question: "What does a row with true premises and a false conclusion indicate?", answer: "The argument is invalid.", points: 200 },
+    { question: "In a truth table, what do 'T' and 'F' stand for?", answer: "True and False.", points: 300 },
+    { question: "Must a valid argument have all true premises?", answer: "No, validity concerns form, not truth of premises.", points: 400 },
+    { question: "What is the purpose of a partial truth table?", answer: "To find a counterexample without completing every row.", points: 500 }
+  ]
+};


### PR DESCRIPTION
## Summary
- add midterm review questions for logic focusing on material up to truth tables
- add final review questions for logic covering the rest of propositional logic plus predicate and modal logic

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685b03b483a08322afd636eebfaba344