### PR TITLE
Add logic review games and unify course styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,6 +77,11 @@
           <a class="button" href="trivia/trivia.html?course=logic" title="Trivia – Quick logic quiz">Trivia</a>
           <a class="button" href="truth-tables/symbolization.html?course=logic" title="Truth Tables – Evaluate argument forms">Truth Tables</a>
           <a class="button" href="prover/prover.html?course=logic" title="Proof Lab – Practice derivations">Proof Lab</a>
+          <a class="button review-btn" href="#" title="Exam Review – Choose a midterm or final game">Review Games</a>
+          <div class="exam-dropdown hidden" hidden>
+            <button onclick="location.href='jeopardy/index.html?topic=logic&exam=Midterm'" title="Part 1 – Midterm Jeopardy">Part 1</button>
+            <button onclick="location.href='jeopardy/index.html?topic=logic&exam=Final'" title="Part 2 – Final Jeopardy">Part 2</button>
+          </div>
         </div>
         <div class="course-progress"><div class="course-progress-bar"></div></div>
       </div>

--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -55,7 +55,7 @@ body {
 
 a.button {
   background-color: #9c27b0;
-  color: white;
+  color: #111;
   padding: 10px 16px;
   margin: 0 8px;
   border-radius: 8px;
@@ -179,7 +179,7 @@ html.review #quote-sidebar {
   flex-direction: column;
   align-items: center;
   margin: 0 8px 16px;
-  background: #1e1e1e;
+  background: #111;
   padding: 20px;
   border-radius: 12px;
   width: 100%;
@@ -237,7 +237,7 @@ body.home .course[data-course="ethics"] a.button:hover {
 }
 
 body.home .course[data-course="logic"] {
-  background: #000;
+  background: #111;
   border-color: #ffeb3b;
 }
 
@@ -247,16 +247,16 @@ body.home .course[data-course="logic"] h3 {
 
 body.home .course[data-course="logic"] a.button {
   background-color: #ffeb3b;
-  color: #000;
+  color: #111;
 }
 
 body.home .course[data-course="logic"] a.button:hover {
   background-color: #fdd835;
-  color: #000;
+  color: #111;
 }
 
 body.home .course[data-course="writing"] {
-  background: #222;
+  background: #111;
   border-color: #555;
 }
 
@@ -284,7 +284,7 @@ body.home .course[data-course="writing"] a.button:hover {
 
 .exam-dropdown button {
   background-color: transparent;
-  color: #000;
+  color: #111;
   font-size: 14px;
   margin-top: 4px;
 }


### PR DESCRIPTION
## Summary
- add missing review game links for Logic course
- unify home course backgrounds with nearly black shade
- set button text to same dark grey

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685b0687cf3083228ae93c3c787707fc