### PR TITLE
Fix truth table order and use horseshoe symbols

### DIFF
--- a/truth-tables/symbolization.html
+++ b/truth-tables/symbolization.html
@@ -37,14 +37,14 @@
       <tr><td>F</td><td>F</td><td>F</td></tr>
     </table>
     <table class="truth-table">
-      <tr><th>P</th><th>Q</th><th>P → Q</th></tr>
+      <tr><th>P</th><th>Q</th><th>P ⊃ Q</th></tr>
       <tr><td>T</td><td>T</td><td>T</td></tr>
       <tr><td>T</td><td>F</td><td>F</td></tr>
       <tr><td>F</td><td>T</td><td>T</td></tr>
       <tr><td>F</td><td>F</td><td>T</td></tr>
     </table>
     <table class="truth-table">
-      <tr><th>P</th><th>Q</th><th>P ↔ Q</th></tr>
+      <tr><th>P</th><th>Q</th><th>P ≡ Q</th></tr>
       <tr><td>T</td><td>T</td><td>T</td></tr>
       <tr><td>T</td><td>F</td><td>F</td></tr>
       <tr><td>F</td><td>T</td><td>F</td></tr>
@@ -52,10 +52,10 @@
     </table>
 
     <h2>Symbolization Practice</h2>
-    <div class="symbolize mc-question" data-answer="R → W">
+      <div class="symbolize mc-question" data-answer="R ⊃ W">
       <p>If it rains, then the ground is wet.</p>
       <div class="mc-options">
-        <button class="option-btn">R → W</button>
+          <button class="option-btn">R ⊃ W</button>
         <button class="option-btn">R ∧ W</button>
         <button class="option-btn">R ∨ W</button>
       </div>
@@ -66,16 +66,16 @@
       <div class="mc-options">
         <button class="option-btn">S ∧ F</button>
         <button class="option-btn">S ∨ F</button>
-        <button class="option-btn">S → F</button>
+          <button class="option-btn">S ⊃ F</button>
       </div>
       <div class="mc-feedback hidden" hidden></div>
     </div>
-    <div class="symbolize mc-question" data-answer="L ↔ U">
+      <div class="symbolize mc-question" data-answer="L ≡ U">
       <p>The lamp is on if and only if the switch is up.</p>
       <div class="mc-options">
-        <button class="option-btn">L ↔ U</button>
-        <button class="option-btn">L → U</button>
-        <button class="option-btn">U → L</button>
+          <button class="option-btn">L ≡ U</button>
+          <button class="option-btn">L ⊃ U</button>
+          <button class="option-btn">U ⊃ L</button>
       </div>
       <div class="mc-feedback hidden" hidden></div>
     </div>

--- a/truth-tables/truth-tables.js
+++ b/truth-tables/truth-tables.js
@@ -35,8 +35,9 @@ function buildTruthTable(containerId, vars, formulaLabel, compute) {
   for (let i = 0; i < rows; i++) {
     const tr = document.createElement('tr');
     const assignment = {};
+    const index = rows - 1 - i;
     vars.forEach((v, idx) => {
-      const bit = (i >> (vars.length - idx - 1)) & 1;
+      const bit = (index >> (vars.length - idx - 1)) & 1;
       assignment[v] = !!bit;
       const td = document.createElement('td');
       td.textContent = bit ? 'T' : 'F';
@@ -92,8 +93,9 @@ function buildValidityTable(containerId, vars, premises, conclusion) {
   for (let i = 0; i < rows; i++) {
     const tr = document.createElement('tr');
     const assign = {};
+    const index = rows - 1 - i;
     vars.forEach((v, idx) => {
-      const bit = (i >> (vars.length - idx - 1)) & 1;
+      const bit = (index >> (vars.length - idx - 1)) & 1;
       assign[v] = !!bit;
       const td = document.createElement('td');
       td.textContent = bit ? 'T' : 'F';
@@ -177,9 +179,9 @@ function setupTables() {
   if (!document.getElementById('table-1')) return;
   buildTruthTable('table-1', ['P'], 'P ∨ ¬P', a => a.P || !a.P);
   buildTruthTable('table-2', ['P'], 'P ∧ ¬P', a => a.P && !a.P);
-  buildTruthTable('table-3', ['P','Q'], 'P → Q', a => !a.P || a.Q);
+  buildTruthTable('table-3', ['P','Q'], 'P ⊃ Q', a => !a.P || a.Q);
   buildValidityTable('validity', ['P','Q'], [
-    {label: 'P → Q', compute: a => !a.P || a.Q},
+    {label: 'P ⊃ Q', compute: a => !a.P || a.Q},
     {label: 'P', compute: a => a.P}
   ], {label: 'Q', compute: a => a.Q});
   const back = document.getElementById('back-symbolization');


### PR DESCRIPTION
## Summary
- ensure truth table rows start with `T` values at the top
- update formula labels to use horseshoe and triple bar

## Testing
- `git diff --cached --stat`

------
https://chatgpt.com/codex/tasks/task_e_685b0940131483228449d65002fdf3a8