### PR TITLE
Add white text color for writing course buttons

### DIFF
--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -266,10 +266,12 @@ body.home .course[data-course="writing"] h3 {
 
 body.home .course[data-course="writing"] a.button {
   background-color: #424242;
+  color: #fff;
 }
 
 body.home .course[data-course="writing"] a.button:hover {
   background-color: #616161;
+  color: #fff;
 }
 
 .exam-dropdown {


### PR DESCRIPTION
## Summary
- ensure writing course buttons have white text on both normal and hover states

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b141c514c8322ae96a151b252b7f2