### PR TITLE
Fix logic review button colors

### DIFF
--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -310,6 +310,16 @@ body.home .course[data-course="ethics"] .exam-dropdown button:hover,
 #topic-selector .course[data-course="ethics"] .exam-dropdown button:hover {
   background-color: #1976d2;
 }
+body.home .course[data-course="logic"] .exam-dropdown button,
+#topic-selector .course[data-course="logic"] .exam-dropdown button {
+  background-color: #ffeb3b;
+  color: #111;
+}
+body.home .course[data-course="logic"] .exam-dropdown button:hover,
+#topic-selector .course[data-course="logic"] .exam-dropdown button:hover {
+  background-color: #fdd835;
+  color: #111;
+}
 
 .game-links {
   display: flex;


### PR DESCRIPTION
## Summary
- add logic exam-dropdown styles so part 1/2 links use the course colors

## Testing
- `pre-commit` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_685b15d5c29483229b4ba720a100bcf2