### PR TITLE
Improve sidebar toggle arrows

### DIFF
--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -560,6 +560,8 @@ button {
   border-radius: 0 6px 6px 0;
   padding: 6px;
   cursor: pointer;
+  width: 32px;
+  text-align: center;
 }
 
 #course-sidebar nav {
@@ -651,6 +653,8 @@ button {
   border-radius: 6px 0 0 6px;
   padding: 6px;
   cursor: pointer;
+  width: 32px;
+  text-align: center;
 }
 
 #quote-game {

--- a/keyterms-sidebar.js
+++ b/keyterms-sidebar.js
@@ -28,7 +28,7 @@ function createKeyTermsSidebar(courseKey) {
   const sidebar = document.createElement('div');
   sidebar.id = 'keyterm-sidebar';
   sidebar.classList.add('collapsed');
-  sidebar.innerHTML = `<button id="keyterm-toggle" aria-label="Toggle Key Terms">\u276E</button>` +
+  sidebar.innerHTML = `<button id="keyterm-toggle" aria-label="Toggle Key Terms">&lsaquo;</button>` +
     `<div id="keyterm-content"><h2>Key Terms</h2><ul class="explain-list">` +
     terms.map(t => `<li><span class="explain-term" data-term="${t}"><em><strong>${t}</strong></em></span></li>`).join('') +
     `</ul></div>`;
@@ -36,7 +36,7 @@ function createKeyTermsSidebar(courseKey) {
   const toggle = sidebar.querySelector('#keyterm-toggle');
   toggle.addEventListener('click', () => {
     const collapsed = sidebar.classList.toggle('collapsed');
-    toggle.innerHTML = collapsed ? '\u276E' : '\u276F';
+    toggle.innerHTML = collapsed ? '&lsaquo;' : '&rsaquo;';
   });
   if (typeof attachExplainHandlers === 'function') {
     attachExplainHandlers();

--- a/page-header.js
+++ b/page-header.js
@@ -32,7 +32,7 @@ function createCourseSidebar() {
   const base = document.currentScript.src.substring(0, document.currentScript.src.lastIndexOf('/'));
   const home = base + '/index.html';
   sidebar.innerHTML = `
-    <button id="course-toggle" aria-label="Toggle course links">\u276E</button>
+    <button id="course-toggle" aria-label="Toggle course links">&lsaquo;</button>
     <nav>
       <a href="${home}#introPhilosophy">Intro</a>
       <a href="${home}#criticalThinking">Critical</a>
@@ -42,7 +42,8 @@ function createCourseSidebar() {
   document.body.appendChild(sidebar);
   const toggle = sidebar.querySelector('#course-toggle');
   if (toggle) toggle.addEventListener('click', () => {
-    sidebar.classList.toggle('collapsed');
+    const collapsed = sidebar.classList.toggle('collapsed');
+    toggle.innerHTML = collapsed ? '&lsaquo;' : '&rsaquo;';
   });
 }
 


### PR DESCRIPTION
## Summary
- update course sidebar arrow in `page-header.js`
- use entities &lsaquo; and &rsaquo; in `keyterms-sidebar.js`
- add width and alignment styles for toggle buttons

## Testing
- `node -e "require('fs').readFileSync('page-header.js')"`


------
https://chatgpt.com/codex/tasks/task_e_685b17f915008322ab4a1f7edab28d31