### PR TITLE
Fix key terms sidebar initialization

### DIFF
--- a/keyterms-sidebar.js
+++ b/keyterms-sidebar.js
@@ -21,6 +21,13 @@ function createKeyTermsSidebar(courseKey) {
       'Practical Wisdom',
       'Philosophical Bullshit',
       'Environmental Impact of AI'
+    ],
+    logic: [
+      'Validity',
+      'Soundness',
+      'Modus Ponens',
+      'Modus Tollens',
+      'Disjunctive Syllogism'
     ]
   };
   const terms = termMap[courseKey];

--- a/page-header.js
+++ b/page-header.js
@@ -1,8 +1,14 @@
 // Dynamic header text based on query parameters
+// Capture the script's base path once so event callbacks can resolve files
+const scriptBase = (function() {
+  const current = document.currentScript;
+  if (!current) return '';
+  const src = current.src;
+  return src.substring(0, src.lastIndexOf('/'));
+})();
+
 function resolvePath(file) {
-  const src = document.currentScript.src;
-  const base = src.substring(0, src.lastIndexOf('/'));
-  return `${base}/${file}`;
+  return scriptBase ? `${scriptBase}/${file}` : file;
 }
 
 function openHelp() {
@@ -29,7 +35,7 @@ function createCourseSidebar() {
   const sidebar = document.createElement('div');
   sidebar.id = 'course-sidebar';
   sidebar.classList.add('collapsed');
-  const base = document.currentScript.src.substring(0, document.currentScript.src.lastIndexOf('/'));
+  const base = scriptBase || '.';
   const home = base + '/index.html';
   sidebar.innerHTML = `
     <button id="course-toggle" aria-label="Toggle course links">&lsaquo;</button>


### PR DESCRIPTION
## Summary
- capture page-header.js script path once
- use stored scriptBase in course sidebar
- add logic course key terms

## Testing
- `node --check page-header.js`
- `node --check keyterms-sidebar.js`


------
https://chatgpt.com/codex/tasks/task_e_685b21d05b0c8322bbef9e141567aaaf