### PR TITLE
Remove debate duel textareas

### DIFF
--- a/debate-duel/debate-duel.html
+++ b/debate-duel/debate-duel.html
@@ -49,11 +49,8 @@
     <div id="reflection" class="hidden" hidden>
       <h3>Reflection Questions</h3>
       <p>After completing this debate, would you keep your original position, or change your mind? Explain why.</p>
-      <textarea rows="3" style="width:90%;"></textarea>
       <p>Which argument was strongest from your opponent, and why?</p>
-      <textarea rows="3" style="width:90%;"></textarea>
       <p>What could you have improved in your own argumentation?</p>
-      <textarea rows="3" style="width:90%;"></textarea>
     </div>
   </div>
   <script src="debate-duel.js"></script>


### PR DESCRIPTION
## Summary
- remove unused `<textarea>` elements from the reflection section of `debate-duel.html`

## Testing
- `npm test` *(fails: package.json missing and network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685b289c6fe88322ab4715b9fc71752b