### PR TITLE
Add visually-hidden sidebar rule

### DIFF
--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -597,6 +597,12 @@ button {
   text-decoration: none;
 }
 
+/* Hide sidebar visually but keep it in the DOM for screen readers */
+#course-sidebar.visually-hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
 #quote-sidebar {
   position: fixed;
   right: 0;


### PR DESCRIPTION
## Summary
- keep course sidebar in the DOM but hide it from view

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b29ac9774832293c86d2e89c98550