### PR TITLE
Allow sidebar expansion on click

### DIFF
--- a/jeopardy/who-said-it.js
+++ b/jeopardy/who-said-it.js
@@ -106,5 +106,13 @@ if (sidebar && toggleBtn) {
     else clearTimeout(hideTimeout);
   });
 
+  sidebar.addEventListener('click', () => {
+    if (sidebar.classList.contains('collapsed')) {
+      sidebar.classList.remove('collapsed');
+      toggleBtn.innerHTML = '&#x276F;';
+      scheduleHide();
+    }
+  });
+
   scheduleHide();
 }

--- a/keyterms-sidebar.js
+++ b/keyterms-sidebar.js
@@ -45,6 +45,13 @@ function createKeyTermsSidebar(courseKey) {
     const collapsed = sidebar.classList.toggle('collapsed');
     toggle.innerHTML = collapsed ? '&lsaquo;' : '&rsaquo;';
   });
+
+  sidebar.addEventListener('click', () => {
+    if (sidebar.classList.contains('collapsed')) {
+      sidebar.classList.remove('collapsed');
+      toggle.innerHTML = '&rsaquo;';
+    }
+  });
   if (typeof attachExplainHandlers === 'function') {
     attachExplainHandlers();
   }


### PR DESCRIPTION
## Summary
- let the key term sidebar open if the sidebar itself is clicked
- let the Who Said It sidebar open when the collapsed div is clicked

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b2a4ac5908322874d9c2687c496ff