### PR TITLE
Improve flashcard contrast and reposition course menu

### DIFF
--- a/flashcards/flashcards.js
+++ b/flashcards/flashcards.js
@@ -34,6 +34,18 @@ const courseColors = {
   logic: '#ffeb3b',
   writing: '#424242'
 };
+
+function lightenColor(hex, factor = 0.6) {
+  hex = hex.replace('#', '');
+  if (hex.length === 3) {
+    hex = hex.split('').map(c => c + c).join('');
+  }
+  const r = parseInt(hex.substr(0, 2), 16);
+  const g = parseInt(hex.substr(2, 2), 16);
+  const b = parseInt(hex.substr(4, 2), 16);
+  const mix = (channel) => Math.round(channel + (255 - channel) * factor);
+  return `rgb(${mix(r)}, ${mix(g)}, ${mix(b)})`;
+}
 let currentCards = [];
 let cardIndex = 0;
 
@@ -57,7 +69,10 @@ function loadCards(course, category = 'all') {
   if (!flashcards[course]) return;
   const color = courseColors[course] || '#9c27b0';
   const wrapper = document.getElementById('flashcard');
-  if (wrapper) wrapper.style.setProperty('--flashcard-color', color);
+  if (wrapper) {
+    wrapper.style.setProperty('--flashcard-color', color);
+    wrapper.style.setProperty('--flashcard-bg', lightenColor(color));
+  }
   const allCards = category === 'all'
     ? Object.values(flashcards[course]).flat()
     : (flashcards[course][category] || []);

--- a/flashcards/style.css
+++ b/flashcards/style.css
@@ -1,5 +1,6 @@
 #flashcard {
   --flashcard-color: #9c27b0; /* default accent color */
+  --flashcard-bg: #d1a9e1;    /* lightened default color */
   margin: 20px auto;
   max-width: 600px;
   position: relative;
@@ -34,8 +35,9 @@ body.flashcard-page .container {
 
 .flip-card-front,
 .flip-card-back {
-  background: var(--flashcard-color);
+  background: var(--flashcard-bg);
   border: 1px solid var(--flashcard-color);
+  color: #000;
 }
 
 #flashcard button {

--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -176,11 +176,16 @@ html.review #quote-sidebar {
 }
 
 #topic-selector {
+  position: fixed;
+  top: 10px;
+  left: 10px;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  gap: 20px;
-  margin-top: 20px;
+  align-items: flex-start;
+  gap: 12px;
+  padding-right: 8px;
+  max-height: 90vh;
+  overflow-y: auto;
 }
 
 #topic-selector button {
@@ -199,13 +204,12 @@ html.review #quote-sidebar {
   position: relative;
   display: flex;
   flex-direction: column;
-  align-items: center;
-  margin: 0 8px 16px;
+  align-items: flex-start;
+  margin: 0 0 12px 0;
   background: #111;
-  padding: 20px;
-  border-radius: 12px;
-  width: 100%;
-  max-width: 520px;
+  padding: 16px;
+  border-radius: 8px;
+  width: 260px;
   border-left: 8px solid transparent;
 }
 
@@ -354,14 +358,10 @@ body.home .course[data-course="logic"] .exam-dropdown button:hover,
 /* On the homepage, arrange links in three columns and force the
    "Review Games" button to appear on its own third row */
 body.home .game-links {
-  display: grid;
-  grid-template-columns: repeat(3, auto);
-  justify-content: center;
-}
-
-body.home .game-links .review-btn {
-  grid-column: 1 / -1;
-  grid-row: 3;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  flex-wrap: nowrap;
 }
 
 .course h3 {


### PR DESCRIPTION
## Summary
- dark text for flashcards and lighter background shades
- compute lightened color in JS
- move course selector menu to the top left as a fixed sidebar
- shrink and simplify course cards

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_685b2dc70c148322916cf3c86785df61