### PR TITLE
Fix key term sidebar toggle

### DIFF
--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -664,10 +664,14 @@ button {
   cursor: pointer;
 }
 
-#quote-sidebar.collapsed #quote-toggle,
-#keyterm-sidebar.collapsed #keyterm-toggle {
+#quote-sidebar.collapsed #quote-toggle {
   position: fixed;
   right: 0;
+}
+
+#keyterm-sidebar.collapsed #keyterm-toggle {
+  position: absolute;
+  left: 0;
 }
 
 


### PR DESCRIPTION
## Summary
- show the key terms sidebar arrow on the left of the handle in both states

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685b3024b4e88322b929f99703ad9ef0