### PR TITLE
Move course sidebar to hamburger menu

### DIFF
--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -546,8 +546,7 @@ button {
 #course-sidebar {
   position: fixed;
   left: 0;
-  top: 50%;
-  transform: translateY(-50%);
+  top: 60px;
   background: #1e1e1e;
   border-right: 2px solid #7b1fa2;
   padding: 10px;
@@ -557,24 +556,22 @@ button {
 }
 
 #course-sidebar.collapsed {
-  transform: translate(calc(-100% + 32px), -50%);
+  transform: translateX(calc(-100% + 40px));
 }
 
 @media (min-width: 768px) {
   #course-sidebar {
-    bottom: 0;
-    top: auto;
-    transform: none;
+    top: 60px;
   }
 
   #course-sidebar.collapsed {
-    transform: translateX(calc(-100% + 32px));
+    transform: translateX(calc(-100% + 40px));
   }
 }
 
 #course-toggle {
   position: absolute;
-  right: -32px;
+  right: -40px;
   top: 10px;
   background: #9c27b0;
   color: #ffeb3b;
@@ -582,7 +579,7 @@ button {
   border-radius: 0 6px 6px 0;
   padding: 6px;
   cursor: pointer;
-  width: 32px;
+  width: 40px;
   text-align: center;
 }
 

--- a/page-header.js
+++ b/page-header.js
@@ -38,18 +38,19 @@ function createCourseSidebar() {
   const base = scriptBase || '.';
   const home = base + '/index.html';
   sidebar.innerHTML = `
-    <button id="course-toggle" aria-label="Toggle course links">&lsaquo;</button>
+    <button id="course-toggle" aria-label="Toggle course links">&#9776;</button>
     <nav>
       <a href="${home}#introPhilosophy">Intro</a>
       <a href="${home}#criticalThinking">Critical</a>
       <a href="${home}#ethics">Ethics</a>
       <a href="${home}#logic">Logic</a>
+      <a href="${home}#writing">Writing</a>
     </nav>`;
   document.body.appendChild(sidebar);
   const toggle = sidebar.querySelector('#course-toggle');
   if (toggle) toggle.addEventListener('click', () => {
     const collapsed = sidebar.classList.toggle('collapsed');
-    toggle.innerHTML = collapsed ? '&lsaquo;' : '&rsaquo;';
+    toggle.textContent = collapsed ? '\u2630' : '\u00d7';
   });
 }
 


### PR DESCRIPTION
## Summary
- reposition course sidebar to the top-left
- use a hamburger toggle and show a close icon when open
- include link to Writing in Philosophy

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b3111b2ec8322a6e85d012a50170f