### PR TITLE
Update home topic selector layout

### DIFF
--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -188,6 +188,20 @@ html.review #quote-sidebar {
   overflow-y: auto;
 }
 
+body.home #topic-selector {
+  position: static;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 12px;
+  margin-top: 20px;
+}
+
+body.home #topic-selector .course {
+  width: 260px;
+  margin: 8px;
+}
+
 #topic-selector button {
   background-color: #9c27b0;
   color: white;


### PR DESCRIPTION
## Summary
- center course selector on homepage instead of fixed sidebar
- keep consistent card margins in the new layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b3504d2448322b457262b1fc24588