### PR TITLE
Adjust key term sidebar collapse

### DIFF
--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -681,8 +681,8 @@ button {
 }
 
 #keyterm-sidebar.collapsed #keyterm-toggle {
-  position: absolute;
-  left: 0;
+  position: fixed;
+  right: 0;                /* match quote sidebar behavior */
 }
 
 

--- a/keyterms-sidebar.js
+++ b/keyterms-sidebar.js
@@ -47,10 +47,8 @@ function createKeyTermsSidebar(courseKey) {
   });
 
   sidebar.addEventListener('click', () => {
-    if (sidebar.classList.contains('collapsed')) {
-      sidebar.classList.remove('collapsed');
-      toggle.innerHTML = '&rsaquo;';
-    }
+    const collapsed = sidebar.classList.toggle('collapsed');
+    toggle.innerHTML = collapsed ? '&lsaquo;' : '&rsaquo;';
   });
   if (typeof attachExplainHandlers === 'function') {
     attachExplainHandlers();


### PR DESCRIPTION
## Summary
- ensure the key terms sidebar toggle stays fixed to the screen edge
- allow clicking the key terms sidebar to both expand and collapse

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685b35d89ccc832295e4280b8c61a5dd