### PR TITLE
Set flashcard button text color to black

### DIFF
--- a/flashcards/style.css
+++ b/flashcards/style.css
@@ -42,4 +42,5 @@ body.flashcard-page .container {
 
 #flashcard button {
   background-color: var(--flashcard-color);
+  color: #000;
 }

--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -1134,7 +1134,7 @@ body.writing-page #writing-sections section {
 #flashcard button,
 #trivia-game button {
   background-color: #9c27b0;
-  color: #ffffff;
+  color: #000;
   border: none;
   padding: 10px 16px;
   margin: 4px;


### PR DESCRIPTION
## Summary
- set black button text for flashcards in `flashcards/style.css`
- match button color for flashcards and trivia in `jeopardy/style.css`

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685b3c88d08483229b786e49a6b7bdc1