### PR TITLE
Adjust homepage CSS for responsiveness

### DIFF
--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -156,7 +156,8 @@ body.home {
   flex: 1;
   display: flex;
   flex-direction: column;
-  margin: 20px auto 0;
+  max-width: 1200px;
+  margin: 0 auto;
 }
 
 .home-container #quote-sidebar {
@@ -191,7 +192,7 @@ html.review #quote-sidebar {
 body.home #topic-selector {
   position: static;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
   gap: 12px;
   margin-top: 20px;
 }
@@ -222,7 +223,7 @@ body.home #topic-selector .course {
   background: #111;
   padding: 16px;
   border-radius: 8px;
-  width: 260px;
+  min-width: 320px;
   border-left: 8px solid transparent;
 }
 


### PR DESCRIPTION
## Summary
- tweak Jeopardy homepage layout
- let course cards size flexibly and limit width of container

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685b3c82960c83229f1df41ef7d265b6