### PR TITLE
Fix sidebar toggling for who-said-it

### DIFF
--- a/jeopardy/who-said-it.js
+++ b/jeopardy/who-said-it.js
@@ -107,9 +107,11 @@ if (sidebar && toggleBtn) {
   });
 
   sidebar.addEventListener('click', () => {
-    if (sidebar.classList.contains('collapsed')) {
-      sidebar.classList.remove('collapsed');
-      toggleBtn.innerHTML = '&#x276F;';
+    const collapsed = sidebar.classList.toggle('collapsed');
+    toggleBtn.innerHTML = collapsed ? '&#x276E;' : '&#x276F;';
+    if (collapsed) {
+      clearTimeout(hideTimeout);
+    } else {
       scheduleHide();
     }
   });


### PR DESCRIPTION
## Summary
- expand or collapse the sidebar when clicking anywhere inside it
- update arrow icon and hide timer when sidebar state changes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b3e11c4988322b8e7a2cc74563edf