### PR TITLE
Fix keyterm toggle placement when collapsed

### DIFF
--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -686,7 +686,7 @@ button {
 
 #keyterm-sidebar.collapsed #keyterm-toggle {
   position: fixed;
-  right: 20px;                /* match quote sidebar behavior */
+  right: calc(20px + 32px); /* sit slightly left of sidebar */
 }
 
 


### PR DESCRIPTION
## Summary
- position the keyterm toggle slightly left of the collapsed sidebar
- confirm the button's z-index remains higher than the sidebar

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685b3efdbf7483229bf76d4075b0cfe5