### PR TITLE
Adjust collapsed sidebar offset

### DIFF
--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -649,7 +649,7 @@ button {
 
 #quote-sidebar.collapsed,
 #keyterm-sidebar.collapsed {
-  right: -208px; /* width minus visible handle */
+  right: -238px; /* shift further off-screen */
   transform: translateY(-50%);
 }
 
@@ -661,14 +661,14 @@ button {
   }
 
   #quote-sidebar.collapsed {
-    right: -208px;
+    right: -238px;
     transform: translateY(-50%);
   }
 }
 
 #keyterm-sidebar.collapsed #keyterm-toggle {
   position: fixed;
-  right: calc(20px + 32px); /* sit slightly left of sidebar */
+  right: 22px; /* keep handle aligned with collapsed sidebar */
 }
 
 


### PR DESCRIPTION
## Summary
- push `quote-sidebar` and `keyterm-sidebar` 30px further off‑screen when collapsed
- keep toggle for keyterm sidebar aligned with new position

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b454b69c483228790c5957be6bc95