### PR TITLE
Enhance sidebar course links

### DIFF
--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -611,6 +611,26 @@ button {
   text-decoration: none;
 }
 
+#course-sidebar a[data-course="introPhilosophy"] {
+  color: #9c27b0;
+}
+
+#course-sidebar a[data-course="criticalThinking"] {
+  color: #f44336;
+}
+
+#course-sidebar a[data-course="ethics"] {
+  color: #2196f3;
+}
+
+#course-sidebar a[data-course="logic"] {
+  color: #ffeb3b;
+}
+
+#course-sidebar a[data-course="writing"] {
+  color: #424242;
+}
+
 /* Hide sidebar visually but keep it in the DOM for screen readers */
 #course-sidebar.visually-hidden {
   opacity: 0;

--- a/page-header.js
+++ b/page-header.js
@@ -40,11 +40,11 @@ function createCourseSidebar() {
   sidebar.innerHTML = `
     <button id="course-toggle" aria-label="Toggle course links">&#9776;</button>
     <nav>
-      <a href="${home}#introPhilosophy">Intro</a>
-      <a href="${home}#criticalThinking">Reasoning</a>
-      <a href="${home}#ethics">Ethics</a>
-      <a href="${home}#logic">Logic</a>
-      <a href="${home}#writing">Writing</a>
+      <a href="${home}#introPhilosophy" data-course="introPhilosophy">Intro</a>
+      <a href="${home}#criticalThinking" data-course="criticalThinking">Reasoning</a>
+      <a href="${home}#ethics" data-course="ethics">Ethics</a>
+      <a href="${home}#logic" data-course="logic">Logic</a>
+      <a href="${home}#writing" data-course="writing">Writing</a>
     </nav>`;
   document.body.appendChild(sidebar);
   const toggle = sidebar.querySelector('#course-toggle');


### PR DESCRIPTION
## Summary
- add course-specific `data-course` attributes to sidebar links
- color course sidebar links using course color palette

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b455c3ea483228469623f1e826f31