### PR TITLE
Limit trivia game question count

### DIFF
--- a/trivia/trivia.js
+++ b/trivia/trivia.js
@@ -80,8 +80,10 @@ function loadTrivia(course, category = 'all') {
   const all = category === 'all'
     ? Object.values(triviaQuestions[course]).flat()
     : (triviaQuestions[course][category] || []);
-  currentTrivia = all;
+  currentTrivia = all.slice();
   shuffle(currentTrivia);
+  // Limit each trivia session to at most 10 questions
+  currentTrivia = currentTrivia.slice(0, 10);
   triviaIndex = 0;
   questionsAnswered = 0;
   correctCount = 0;


### PR DESCRIPTION
## Summary
- cap trivia sessions at ten questions

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685b4e595ca88322a6f38e7f210d8c42