### PR TITLE
Adjust collapsed sidebar offsets

### DIFF
--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -644,7 +644,7 @@ button {
   top: 50%;
   transform: translateY(-50%);
   background: #1e1e1e;
-  border-left: 2px solid #7b1fa2;
+  border-left: 7px solid #7b1fa2;
   padding: 10px;
   width: 260px;
   max-width: 80vw;
@@ -658,7 +658,7 @@ button {
   top: 50%;
   transform: translateY(-50%);
   background: #1e1e1e;
-  border-left: 2px solid #009688;
+  border-left: 7px solid #009688;
   padding: 10px;
   width: 260px;
   max-width: 80vw;
@@ -670,7 +670,7 @@ button {
 
 #quote-sidebar.collapsed,
 #keyterm-sidebar.collapsed {
-  right: -253px; /* shift further off-screen */
+  right: -263px; /* shift further off-screen */
   transform: translateY(-50%);
 }
 
@@ -682,14 +682,14 @@ button {
   }
 
   #quote-sidebar.collapsed {
-    right: -253px;
+    right: -263px;
     transform: translateY(-50%);
   }
 }
 
 #keyterm-sidebar.collapsed #keyterm-toggle {
   position: fixed;
-  right: 22px; /* keep handle aligned with collapsed sidebar */
+  right: 32px; /* keep handle aligned with collapsed sidebar */
 }
 
 


### PR DESCRIPTION
## Summary
- shift key terms and quote sidebars 10px further right when collapsed
- widen the colored border on these sidebars

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685b4f7acef48322ba716eec99a46f65