### PR TITLE
Improve multiple choice option relevance

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This repository contains a set of lightweight browser games that let you review 
 - Single-player mode lets you enter your name, displayed next to your score
 - Simple flashcards page for quick review
 - Multiple-choice trivia game for each course
+- Smarter multiple-choice options for person-based questions
 - "Who Said It?" quote quiz
 - Ethics Chat page with rotating philosopher perspectives
 - Intro Philosophy Chat covering ancient Greek thinkers

--- a/jeopardy/script.js
+++ b/jeopardy/script.js
@@ -10,8 +10,17 @@ function buildChoices(correct) {
     .flat()
     .map(q => q.answer);
   const others = answers.filter(a => a !== correct);
-  shuffle(others);
-  const choices = others.slice(0, 3).concat(correct);
+
+  let filtered = others;
+  if (typeof looksLikePerson === 'function' && looksLikePerson(correct)) {
+    const names = others.filter(a => looksLikePerson(a));
+    if (names.length >= 3) {
+      filtered = names;
+    }
+  }
+
+  shuffle(filtered);
+  const choices = filtered.slice(0, 3).concat(correct);
   shuffle(choices);
   return choices;
 }

--- a/trivia/trivia.js
+++ b/trivia/trivia.js
@@ -100,8 +100,15 @@ function buildChoices(question) {
   }
   const answers = currentTrivia.map(q => q.answer);
   const others = answers.filter(a => a !== question.answer);
-  shuffle(others);
-  const choices = others.slice(0, 3).concat(question.answer);
+  let filtered = others;
+  if (typeof looksLikePerson === 'function' && looksLikePerson(question.answer)) {
+    const names = others.filter(a => looksLikePerson(a));
+    if (names.length >= 3) {
+      filtered = names;
+    }
+  }
+  shuffle(filtered);
+  const choices = filtered.slice(0, 3).concat(question.answer);
   shuffle(choices);
   return choices;
 }

--- a/utils.js
+++ b/utils.js
@@ -5,6 +5,21 @@ function shuffle(arr) {
   }
 }
 
+function looksLikePerson(answer) {
+  const words = answer.trim().split(/\s+/);
+  if (words.length === 0 || words.length > 4) return false;
+  return words.every(w => /^[A-Z][A-Za-z\u00C0-\u017F'\-]*$/.test(w));
+}
+
+function questionExpectsPerson(question, answer) {
+  if (/\bwho\b|which (philosopher|thinker|person)|\bwhose\b/i.test(question)) {
+    return true;
+  }
+  return looksLikePerson(answer);
+}
+
 if (typeof window !== 'undefined') {
   window.shuffle = shuffle;
+  window.looksLikePerson = looksLikePerson;
+  window.questionExpectsPerson = questionExpectsPerson;
 }


### PR DESCRIPTION
## Summary
- detect whether answers look like people's names
- build better options in Jeopardy and Trivia when questions expect a person
- expose name-check utilities globally
- document the smarter options in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685b550279e083229f14dad81ff7f7fd