### PR TITLE
Fix chat alignment for user messages

### DIFF
--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -835,6 +835,8 @@ button {
 .chat-message.chat-user {
   flex-direction: row-reverse;
   justify-content: flex-end;
+  margin-left: auto;
+  text-align: right;
 }
 
 .chat-message.chat-user img.profile-pic {


### PR DESCRIPTION
## Summary
- align user chat bubbles to the right

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b62a7e5d083228f39a0a2666d7646