### PR TITLE
Add emoji controls and color theme toggle

### DIFF
--- a/chatbots/ethics-chat-engine.js
+++ b/chatbots/ethics-chat-engine.js
@@ -1,6 +1,9 @@
 (function() {
   const chatBox = document.getElementById('chat-box');
   const controls = document.getElementById('chat-controls');
+  const extras = document.getElementById('chat-extras');
+  const colorToggle = extras ? extras.querySelector('#color-toggle') : null;
+  const emojiButtons = extras ? extras.querySelectorAll('.emoji-btn') : [];
   const bots = window.ethicalChatbots || {};
   let current = 'Philosophy Student';
   let exchangeIndex = 0;
@@ -25,12 +28,20 @@
     'Philosophy Student': '../assets/images/student.png'
   };
 
+  let useSpeakerColors = true;
+
   async function addMessage(speaker, text, className) {
     if (!className) {
       className = speakerClasses[speaker] || 'chat-bot';
     }
     const div = document.createElement('div');
-    div.className = `chat-message ${className}`;
+    div.dataset.speaker = speaker;
+    div.dataset.speakerClass = className;
+    const baseClass = speaker === 'You' ? 'chat-user' : 'chat-bot';
+    div.className = `chat-message ${baseClass}`;
+    if (useSpeakerColors && className && baseClass !== className) {
+      div.classList.add(className);
+    }
     const img = speakerImages[speaker]
       ? `<img src="${speakerImages[speaker]}" alt="${speaker}" class="profile-pic">`
       : '';
@@ -45,7 +56,7 @@
       div.innerHTML = `${img}<strong>${speaker}:</strong> ${text}`;
       chatBox.scrollTop = chatBox.scrollHeight;
     } else {
-      div.innerHTML = `${img}<strong>${speaker}:</strong> ${text}`;
+      div.innerHTML = `${text} <strong>${speaker}</strong> ${img}`;
       chatBox.appendChild(div);
       chatBox.scrollTop = chatBox.scrollHeight;
     }
@@ -115,6 +126,32 @@
     if (ex.transition) await addMessage(current, ex.transition);
     await addMessage(current, ex.question);
     showOptions(ex.responses, ex.theoristView);
+  }
+
+  function updateColors() {
+    const msgs = chatBox.querySelectorAll('.chat-message');
+    msgs.forEach(m => {
+      const speakerClass = m.dataset.speakerClass;
+      const speaker = m.dataset.speaker;
+      const base = speaker === 'You' ? 'chat-user' : 'chat-bot';
+      m.className = `chat-message ${base}`;
+      if (useSpeakerColors && speakerClass && base !== speakerClass) {
+        m.classList.add(speakerClass);
+      }
+    });
+  }
+
+  if (colorToggle) {
+    colorToggle.addEventListener('click', () => {
+      useSpeakerColors = !useSpeakerColors;
+      updateColors();
+    });
+  }
+
+  if (emojiButtons.length) {
+    emojiButtons.forEach(btn => {
+      btn.addEventListener('click', () => addMessage('You', btn.textContent, 'chat-user'));
+    });
   }
 
   async function startConversation() {

--- a/chatbots/ethics-chat.html
+++ b/chatbots/ethics-chat.html
@@ -16,6 +16,12 @@
     <h1>Moral Theorists Group Chat</h1>
     <p class="instructions">Discuss dilemmas with famous ethicists in a rotating conversation.</p>
     <div id="chat-box"></div>
+    <div id="chat-extras">
+      <button class="emoji-btn">😊</button>
+      <button class="emoji-btn">👍</button>
+      <button class="emoji-btn">😢</button>
+      <button id="color-toggle">Toggle Colors</button>
+    </div>
     <div id="chat-controls"></div>
   </div>
   <script src="ethical-chatbot.js"></script>

--- a/chatbots/intro-philosophy-chat.html
+++ b/chatbots/intro-philosophy-chat.html
@@ -16,6 +16,12 @@
     <h1>Ancient Greek Philosophy Chat</h1>
     <p class="instructions">Chat with early thinkers to explore classic ideas.</p>
     <div id="chat-box"></div>
+    <div id="chat-extras">
+      <button class="emoji-btn">😊</button>
+      <button class="emoji-btn">👍</button>
+      <button class="emoji-btn">😢</button>
+      <button id="color-toggle">Toggle Colors</button>
+    </div>
     <div id="chat-controls"></div>
   </div>
   <script src="intro-philosophy-chatbot-revised.js"></script>

--- a/chatbots/intro-philosophy-chatbot-revised.js
+++ b/chatbots/intro-philosophy-chatbot-revised.js
@@ -143,6 +143,9 @@ const philosophyChatSteps = [
 (function() {
   const chatBox = document.getElementById('chat-box');
   const controls = document.getElementById('chat-controls');
+  const extras = document.getElementById('chat-extras');
+  const colorToggle = extras ? extras.querySelector('#color-toggle') : null;
+  const emojiButtons = extras ? extras.querySelectorAll('.emoji-btn') : [];
   let stepIndex = 0;
   let awaitingChoice = false;
   const speakerClasses = {
@@ -164,12 +167,20 @@ const philosophyChatSteps = [
     'Aristotle': '../assets/images/aristotle.png'
   };
 
+  let useSpeakerColors = true;
+
   async function addMessage(speaker, text, className) {
     if (!className) {
       className = speakerClasses[speaker] || 'chat-bot';
     }
     const div = document.createElement('div');
-    div.className = `chat-message ${className}`;
+    div.dataset.speaker = speaker;
+    div.dataset.speakerClass = className;
+    const baseClass = speaker === 'You' ? 'chat-user' : 'chat-bot';
+    div.className = `chat-message ${baseClass}`;
+    if (useSpeakerColors && className && baseClass !== className) {
+      div.classList.add(className);
+    }
     const img = speakerImages[speaker]
       ? `<img src="${speakerImages[speaker]}" alt="${speaker}" class="profile-pic">`
       : '';
@@ -184,7 +195,7 @@ const philosophyChatSteps = [
       div.innerHTML = `${img}<strong>${speaker}:</strong> ${text}`;
       chatBox.scrollTop = chatBox.scrollHeight;
     } else {
-      div.innerHTML = `${img}<strong>${speaker}:</strong> ${text}`;
+      div.innerHTML = `${text} <strong>${speaker}</strong> ${img}`;
       chatBox.appendChild(div);
       chatBox.scrollTop = chatBox.scrollHeight;
     }
@@ -222,6 +233,32 @@ const philosophyChatSteps = [
     if (stepIndex < philosophyChatSteps.length) {
       setTimeout(showStep, 500);
     }
+  }
+
+  function updateColors() {
+    const msgs = chatBox.querySelectorAll('.chat-message');
+    msgs.forEach(m => {
+      const speakerClass = m.dataset.speakerClass;
+      const speaker = m.dataset.speaker;
+      const base = speaker === 'You' ? 'chat-user' : 'chat-bot';
+      m.className = `chat-message ${base}`;
+      if (useSpeakerColors && speakerClass && base !== speakerClass) {
+        m.classList.add(speakerClass);
+      }
+    });
+  }
+
+  if (colorToggle) {
+    colorToggle.addEventListener('click', () => {
+      useSpeakerColors = !useSpeakerColors;
+      updateColors();
+    });
+  }
+
+  if (emojiButtons.length) {
+    emojiButtons.forEach(btn => {
+      btn.addEventListener('click', () => addMessage('You', btn.textContent, 'chat-user'));
+    });
   }
 
   async function showStep() {

--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -810,23 +810,26 @@ button {
 }
 
 #chat-box {
-  background: #1e1e1e;
+  background: linear-gradient(#2b2b2b, #1e1e1e);
   padding: 10px;
   height: 400px;
   overflow-y: auto;
   border-radius: 8px;
   margin-bottom: 10px;
   text-align: left;
+  border: 2px solid #444;
+  box-shadow: 0 2px 4px rgba(0,0,0,0.4);
 }
 
 .chat-message {
   margin: 6px 0;
-  display: flex;
+  display: inline-flex;
   align-items: flex-start;
   padding: 6px 10px;
   border-radius: 12px;
   background: #333;
   color: #fff;
+  width: fit-content;
   max-width: 80%;
 }
 
@@ -873,6 +876,32 @@ button {
   display: flex;
   gap: 8px;
   justify-content: center;
+}
+
+#chat-extras {
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  margin-bottom: 6px;
+}
+
+.emoji-btn {
+  font-size: 20px;
+  background: #2b2b2b;
+  color: #fff;
+  border: none;
+  padding: 4px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+#color-toggle {
+  background: var(--accent-light);
+  color: #000;
+  border: none;
+  padding: 6px 12px;
+  border-radius: 6px;
+  cursor: pointer;
 }
 
 #user-input {


### PR DESCRIPTION
## Summary
- add an emoji bar and a color toggle button to chat pages
- style chat bubbles with dynamic width and chat window flair
- reverse user message layout and allow toggling philosopher colors
- implement emoji sending and color toggle logic

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685b6898dcfc8322a57aa501d04868bd