### PR TITLE
Implement name input in chatbots

### DIFF
--- a/chatbots/ethics-chat-engine.js
+++ b/chatbots/ethics-chat-engine.js
@@ -8,6 +8,7 @@
   let current = 'Philosophy Student';
   let exchangeIndex = 0;
   let awaitingChoice = false;
+  let userName = '';
   const alignmentScores = {};
   const speakerClasses = {
     'John Stuart Mill': 'speaker-mill',
@@ -96,11 +97,11 @@
         const score = alignmentScores[current] || 0;
         let closing;
         if (score === exchanges.length) {
-          closing = data.closings.highAlignment('');
+          closing = data.closings.highAlignment(userName);
         } else if (score > 0) {
-          closing = data.closings.moderateAlignment('');
+          closing = data.closings.moderateAlignment(userName);
         } else {
-          closing = data.closings.lowAlignment('');
+          closing = data.closings.lowAlignment(userName);
         }
         await addMessage(current, closing);
       }
@@ -109,14 +110,14 @@
       current = next;
       exchangeIndex = 0;
       if (current === 'Philosophy Student') {
-        const finalText = bots['Philosophy Student'].finalAssessment('', alignmentScores);
+        const finalText = bots['Philosophy Student'].finalAssessment(userName, alignmentScores);
         await addMessage('Philosophy Student', finalText);
         controls.innerHTML = '';
         return;
       }
       alignmentScores[current] = 0;
       const greet = typeof bots[current].greeting === 'function'
-        ? bots[current].greeting('')
+        ? bots[current].greeting(userName)
         : bots[current].greeting;
       await addMessage(current, greet);
       setTimeout(showExchange, 500);
@@ -154,9 +155,33 @@
     });
   }
 
+  function askForName() {
+    return new Promise(resolve => {
+      controls.innerHTML = '';
+      const input = document.createElement('input');
+      input.type = 'text';
+      const btn = document.createElement('button');
+      btn.textContent = 'Submit';
+      btn.onclick = () => {
+        const val = input.value.trim();
+        if (!/^[A-Za-z]{1,15}$/.test(val)) {
+          alert('Please enter a valid name (letters only, up to 15 characters)');
+          return;
+        }
+        userName = val;
+        controls.innerHTML = '';
+        resolve();
+      };
+      controls.appendChild(input);
+      controls.appendChild(btn);
+    });
+  }
+
   async function startConversation() {
+    await addMessage('Philosophy Student', "Hey there! What's your name?");
+    await askForName();
     const student = bots['Philosophy Student'];
-    const greet = typeof student.greeting === 'function' ? student.greeting('') : student.greeting;
+    const greet = typeof student.greeting === 'function' ? student.greeting(userName) : student.greeting;
     await addMessage('Philosophy Student', greet);
     if (student.introduceMill) {
       await addMessage('Philosophy Student', student.introduceMill);
@@ -164,7 +189,7 @@
     current = 'John Stuart Mill';
     alignmentScores[current] = 0;
     const firstGreet = typeof bots[current].greeting === 'function'
-      ? bots[current].greeting('')
+      ? bots[current].greeting(userName)
       : bots[current].greeting;
     await addMessage(current, firstGreet);
     showExchange();

--- a/chatbots/intro-philosophy-chatbot-revised.js
+++ b/chatbots/intro-philosophy-chatbot-revised.js
@@ -1,7 +1,7 @@
 const philosophyChatSteps = [
   {
     messages: [
-      { speaker: "Philosophy Student", text: "Hey there! I’m studying philosophy and also a bit of computer science. Ancient Greek philosophy can feel pretty abstract, so I created this AI chat to talk directly with philosophers like Thales, Socrates, and Plato. Ready to explore reality and existence together?" },
+      { speaker: "Philosophy Student", text: "I’m studying philosophy and also a bit of computer science. Ancient Greek philosophy can feel pretty abstract, so I created this AI chat to talk directly with philosophers like Thales, Socrates, and Plato. Ready to explore reality and existence together?" },
       { speaker: "Philosophy Student", text: "In ancient times, people explained reality through myths and gods. Thales suggested rational observation is better. Do you agree with him that rational explanations really help us understand reality clearly?" }
     ],
     choices: ["Yes", "No", "Unsure"],
@@ -148,6 +148,7 @@ const philosophyChatSteps = [
   const emojiButtons = extras ? extras.querySelectorAll('.emoji-btn') : [];
   let stepIndex = 0;
   let awaitingChoice = false;
+  let userName = '';
   const speakerClasses = {
     'Philosophy Student': 'speaker-student',
     'Thales': 'speaker-thales',
@@ -261,6 +262,28 @@ const philosophyChatSteps = [
     });
   }
 
+  function askForName() {
+    return new Promise(resolve => {
+      controls.innerHTML = '';
+      const input = document.createElement('input');
+      input.type = 'text';
+      const btn = document.createElement('button');
+      btn.textContent = 'Submit';
+      btn.onclick = () => {
+        const val = input.value.trim();
+        if (!/^[A-Za-z]{1,15}$/.test(val)) {
+          alert('Please enter a valid name (letters only, up to 15 characters)');
+          return;
+        }
+        userName = val;
+        controls.innerHTML = '';
+        resolve();
+      };
+      controls.appendChild(input);
+      controls.appendChild(btn);
+    });
+  }
+
   async function showStep() {
     const step = philosophyChatSteps[stepIndex];
     for (const m of step.messages) {
@@ -281,6 +304,10 @@ const philosophyChatSteps = [
     }
   }
 
-  document.addEventListener('DOMContentLoaded', showStep);
+  document.addEventListener('DOMContentLoaded', async () => {
+    await addMessage('Philosophy Student', "Hey there! What's your name?");
+    await askForName();
+    showStep();
+  });
 })();
 


### PR DESCRIPTION
## Summary
- add name prompts for Ethics and Intro Philosophy chats
- capture user name and personalize greetings
- avoid duplicate intro message in philosophy chat

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685b6a228a6083229ee4c64f23af1a9a