### PR TITLE
Enhance chatbots with personalized questions

### DIFF
--- a/chatbots/ethics-chat-engine.js
+++ b/chatbots/ethics-chat-engine.js
@@ -125,7 +125,11 @@
     }
     const ex = exchanges[exchangeIndex];
     if (ex.transition) await addMessage(current, ex.transition);
-    await addMessage(current, ex.question);
+    let questionText = ex.question;
+    if (userName && /\?\s*$/.test(questionText)) {
+      questionText = questionText.replace(/\?\s*$/, `, ${userName}?`);
+    }
+    await addMessage(current, questionText);
     showOptions(ex.responses, ex.theoristView);
   }
 

--- a/chatbots/intro-philosophy-chatbot-revised.js
+++ b/chatbots/intro-philosophy-chatbot-revised.js
@@ -286,7 +286,14 @@ const philosophyChatSteps = [
 
   async function showStep() {
     const step = philosophyChatSteps[stepIndex];
-    for (const m of step.messages) {
+    const messages = step.messages.slice();
+    if (step.choices && userName && messages.length) {
+      const last = messages[messages.length - 1];
+      if (/\?\s*$/.test(last.text)) {
+        last.text = last.text.replace(/\?\s*$/, `, ${userName}?`);
+      }
+    }
+    for (const m of messages) {
       await addMessage(m.speaker, m.text, m.className);
     }
     if (step.choices) {


### PR DESCRIPTION
## Summary
- personalize pre-choice questions by including stored userName in `ethics-chat-engine.js`
- personalize pre-choice questions in `intro-philosophy-chatbot-revised.js`

## Testing
- `npm test` *(fails: ENOENT package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685b6becab1c8322a84335ddbf1996af