### PR TITLE
Add color scheme cycling

### DIFF
--- a/chatbots/ethics-chat-engine.js
+++ b/chatbots/ethics-chat-engine.js
@@ -29,7 +29,8 @@
     'Philosophy Student': '../assets/images/student.png'
   };
 
-  let useSpeakerColors = true;
+  const colorSchemes = ['speaker', 'blue', 'teal', 'purple'];
+  let colorSchemeIndex = 0;
 
   async function addMessage(speaker, text, className) {
     if (!className) {
@@ -39,9 +40,12 @@
     div.dataset.speaker = speaker;
     div.dataset.speakerClass = className;
     const baseClass = speaker === 'You' ? 'chat-user' : 'chat-bot';
+    const scheme = colorSchemes[colorSchemeIndex];
     div.className = `chat-message ${baseClass}`;
-    if (useSpeakerColors && className && baseClass !== className) {
+    if (scheme === 'speaker' && className && baseClass !== className) {
       div.classList.add(className);
+    } else if (scheme !== 'speaker') {
+      div.classList.add(`theme-${scheme}`);
     }
     const img = speakerImages[speaker]
       ? `<img src="${speakerImages[speaker]}" alt="${speaker}" class="profile-pic">`
@@ -134,21 +138,24 @@
   }
 
   function updateColors() {
+    const scheme = colorSchemes[colorSchemeIndex];
     const msgs = chatBox.querySelectorAll('.chat-message');
     msgs.forEach(m => {
       const speakerClass = m.dataset.speakerClass;
       const speaker = m.dataset.speaker;
       const base = speaker === 'You' ? 'chat-user' : 'chat-bot';
       m.className = `chat-message ${base}`;
-      if (useSpeakerColors && speakerClass && base !== speakerClass) {
+      if (scheme === 'speaker' && speakerClass && base !== speakerClass) {
         m.classList.add(speakerClass);
+      } else if (scheme !== 'speaker') {
+        m.classList.add(`theme-${scheme}`);
       }
     });
   }
 
   if (colorToggle) {
     colorToggle.addEventListener('click', () => {
-      useSpeakerColors = !useSpeakerColors;
+      colorSchemeIndex = (colorSchemeIndex + 1) % colorSchemes.length;
       updateColors();
     });
   }

--- a/chatbots/intro-philosophy-chatbot-revised.js
+++ b/chatbots/intro-philosophy-chatbot-revised.js
@@ -168,7 +168,8 @@ const philosophyChatSteps = [
     'Aristotle': '../assets/images/aristotle.png'
   };
 
-  let useSpeakerColors = true;
+  const colorSchemes = ['speaker', 'blue', 'teal', 'purple'];
+  let colorSchemeIndex = 0;
 
   async function addMessage(speaker, text, className) {
     if (!className) {
@@ -178,9 +179,12 @@ const philosophyChatSteps = [
     div.dataset.speaker = speaker;
     div.dataset.speakerClass = className;
     const baseClass = speaker === 'You' ? 'chat-user' : 'chat-bot';
+    const scheme = colorSchemes[colorSchemeIndex];
     div.className = `chat-message ${baseClass}`;
-    if (useSpeakerColors && className && baseClass !== className) {
+    if (scheme === 'speaker' && className && baseClass !== className) {
       div.classList.add(className);
+    } else if (scheme !== 'speaker') {
+      div.classList.add(`theme-${scheme}`);
     }
     const img = speakerImages[speaker]
       ? `<img src="${speakerImages[speaker]}" alt="${speaker}" class="profile-pic">`
@@ -237,21 +241,24 @@ const philosophyChatSteps = [
   }
 
   function updateColors() {
+    const scheme = colorSchemes[colorSchemeIndex];
     const msgs = chatBox.querySelectorAll('.chat-message');
     msgs.forEach(m => {
       const speakerClass = m.dataset.speakerClass;
       const speaker = m.dataset.speaker;
       const base = speaker === 'You' ? 'chat-user' : 'chat-bot';
       m.className = `chat-message ${base}`;
-      if (useSpeakerColors && speakerClass && base !== speakerClass) {
+      if (scheme === 'speaker' && speakerClass && base !== speakerClass) {
         m.classList.add(speakerClass);
+      } else if (scheme !== 'speaker') {
+        m.classList.add(`theme-${scheme}`);
       }
     });
   }
 
   if (colorToggle) {
     colorToggle.addEventListener('click', () => {
-      useSpeakerColors = !useSpeakerColors;
+      colorSchemeIndex = (colorSchemeIndex + 1) % colorSchemes.length;
       updateColors();
     });
   }

--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -868,6 +868,21 @@ button {
   color: #fff;
 }
 
+.theme-blue {
+  background: #2196f3;
+  color: #fff;
+}
+
+.theme-teal {
+  background: #009688;
+  color: #fff;
+}
+
+.theme-purple {
+  background: #9c27b0;
+  color: #fff;
+}
+
 .chat-notice {
   color: #c0c0c0;
   font-style: italic;


### PR DESCRIPTION
## Summary
- allow cycling through speaker or colored theme classes in ethics and intro chatbots
- implement index-based color schemes so color toggle cycles through four options
- add blue/teal/purple theme classes to stylesheet

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_685b6e327818832298a4f95a48dff159