### PR TITLE
Limit chat input width

### DIFF
--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -894,6 +894,10 @@ button {
   display: flex;
   gap: 8px;
   justify-content: center;
+  width: 90%;
+  max-width: 600px;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 #chat-extras {


### PR DESCRIPTION
## Summary
- restrict `#chat-controls` to the same width limits as `#chat-box`

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685b73b0f3c08322971fa881cdf26af2