### PR TITLE
Improve ethics chat UX

### DIFF
--- a/chatbots/ethical-chatbot.js
+++ b/chatbots/ethical-chatbot.js
@@ -10,7 +10,7 @@ const ethicalChatbots = {
 
   "John Stuart Mill": {
     greeting: (userName) =>
-      `Thanks for the intro! I'm John Stuart Mill. For me, morality is about achieving the greatest happiness for the greatest number.`,
+      `Thanks for the introduction! I'm John Stuart Mill. For me, morality is about achieving the greatest happiness for the greatest number.`,
     exchanges: [
       {
         question: "Do you agree morality should primarily focus on maximizing happiness?",
@@ -23,7 +23,7 @@ const ethicalChatbots = {
       },
       {
         transition: "Let's apply this with a classic scenario:",
-        question: `In the <span class="info" title="A runaway trolley will kill five people unless diverted, but diverting it kills one.">trolley problem</span>, would you divert the trolley?`,
+        question: `In the <span class="info" data-tooltip="A runaway trolley will kill five people unless diverted, but diverting it kills one.">trolley problem</span>, would you divert the trolley?`,
         theoristView: "Yes, definitely",
         responses: {
           "Yes, definitely": "Precisely! Choosing the option that saves more lives is morally right.",
@@ -58,7 +58,7 @@ const ethicalChatbots = {
       },
       {
         transition: "Consider this challenging scenario:",
-        question: `In the <span class="info" title="A Nazi solider knocks on your door and asks if you're hiding the Smith family in your basement; if you tell the truth and say yes, the soldier will kill the family and you. Kant argues lying here is still wrong.">Nazi-at-the-door scenario</span>, is lying morally acceptable to save a life?`,
+        question: `In the <span class="info" data-tooltip="A Nazi solider knocks on your door and asks if you're hiding the Smith family in your basement; if you tell the truth and say yes, the soldier will kill the family and you. Kant argues lying here is still wrong.">Nazi-at-the-door scenario</span>, is lying morally acceptable to save a life?`,
         theoristView: "No, not really",
         responses: {
           "Yes, definitely": "Compassionate, but honesty must remain absolute and universal.",

--- a/chatbots/ethics-chat-engine.js
+++ b/chatbots/ethics-chat-engine.js
@@ -204,16 +204,50 @@
     const student = bots['Sage'];
     const greet = typeof student.greeting === 'function' ? student.greeting(userName) : student.greeting;
     await addMessage('Sage', greet);
-    if (student.introduceMill) {
-      await addMessage('Sage', student.introduceMill);
+
+    let selected = null;
+    await new Promise(resolve => {
+      awaitingChoice = true;
+      const options = {
+        "Yes, let's chat!": "Great! Let's dive in.",
+        "Sure, I guess": "No worries, let's take it slow. Here we go.",
+        "No thanks": "Goodbye and good luck learning about ethics!"
+      };
+      controls.innerHTML = '';
+      Object.keys(options).forEach(opt => {
+        const btn = document.createElement('button');
+        btn.className = 'option-btn';
+        btn.textContent = opt;
+        btn.onclick = async () => {
+          if (!awaitingChoice) return;
+          awaitingChoice = false;
+          selected = opt;
+          controls.querySelectorAll('button').forEach(b => b.disabled = true);
+          await addMessage('You', opt, 'chat-user');
+          await addMessage('Sage', options[opt]);
+          if (opt === 'No thanks') {
+            await addMessage('System', 'Chat closed', 'chat-notice');
+            resolve();
+            return;
+          }
+          if (student.introduceMill) {
+            await addMessage('Sage', student.introduceMill);
+          }
+          resolve();
+        };
+        controls.appendChild(btn);
+      });
+    });
+
+    if (selected !== 'No thanks') {
+      current = 'John Stuart Mill';
+      alignmentScores[current] = 0;
+      const firstGreet = typeof bots[current].greeting === 'function'
+        ? bots[current].greeting(userName)
+        : bots[current].greeting;
+      await addMessage(current, firstGreet);
+      showExchange();
     }
-    current = 'John Stuart Mill';
-    alignmentScores[current] = 0;
-    const firstGreet = typeof bots[current].greeting === 'function'
-      ? bots[current].greeting(userName)
-      : bots[current].greeting;
-    await addMessage(current, firstGreet);
-    showExchange();
   }
 
   document.addEventListener('DOMContentLoaded', startConversation);


### PR DESCRIPTION
## Summary
- add confirmation choices after Sage introduction in moral theorists chat
- change tooltip attribute so trolley problem text formats correctly
- fix greeting text for John Stuart Mill

## Testing
- `node -c chatbots/ethical-chatbot.js`
- `node -c chatbots/ethics-chat-engine.js`

------
https://chatgpt.com/codex/tasks/task_e_685b7a2365588322aa946181d3ec606f