### PR TITLE
Add final reflection step to ethics chat

### DIFF
--- a/chatbots/ethical-chatbot.js
+++ b/chatbots/ethical-chatbot.js
@@ -5,7 +5,16 @@ const ethicalChatbots = {
     introduceMill: "First, let's meet John Stuart Mill, who thinks morality is about maximizing happiness.",
     finalAssessment: (userName, alignmentScores) => {
       return `This was great${userName ? `, ${userName}` : ""}! Which parts of each philosopher's theory resonated with you? Which ideas do you disagree with? Thanks for exploring ethics with me—I learned a lot too!`;
-    }
+    },
+    closingQuestion: "Which philosopher's approach do you find most compelling?",
+    closingResponses: {
+      "John Stuart Mill": "Utilitarianism centers morality on outcomes and happiness—an interesting choice!",
+      "Immanuel Kant": "Duty-based ethics is tough but principled. Kant would approve!",
+      "St. Thomas Aquinas": "Natural law and good intentions clearly resonate with you.",
+      "Aristotle": "Virtue ethics focuses on character and flourishing—great pick!",
+      "Nel Noddings": "An ethic of care puts relationships and empathy first."
+    },
+    farewell: "Take care, and keep pondering these perspectives!"
   },
 
   "John Stuart Mill": {

--- a/chatbots/ethics-chat-engine.js
+++ b/chatbots/ethics-chat-engine.js
@@ -121,7 +121,7 @@
       if (current === 'Sage') {
         const finalText = bots['Sage'].finalAssessment(userName, alignmentScores);
         await addMessage('Sage', finalText);
-        controls.innerHTML = '';
+        await showFinalReflection();
         return;
       }
       alignmentScores[current] = 0;
@@ -140,6 +140,41 @@
     }
     await addMessage(current, questionText);
     showOptions(ex.responses, ex.theoristView);
+  }
+
+  async function handleReflectionChoice(option, reply) {
+    if (!awaitingChoice) return;
+    awaitingChoice = false;
+    controls.querySelectorAll('button').forEach(b => b.disabled = true);
+    await addMessage('You', option, 'chat-user');
+    await addMessage('Sage', reply);
+    if (bots['Sage'].farewell) {
+      await addMessage('Sage', bots['Sage'].farewell);
+    }
+    await addMessage('System', 'Chat closed', 'chat-notice');
+    controls.innerHTML = '';
+  }
+
+  async function showFinalReflection() {
+    const question = bots['Sage'].closingQuestion;
+    const responses = bots['Sage'].closingResponses;
+    if (!question || !responses) {
+      if (bots['Sage'].farewell) {
+        await addMessage('Sage', bots['Sage'].farewell);
+      }
+      await addMessage('System', 'Chat closed', 'chat-notice');
+      return;
+    }
+    await addMessage('Sage', question);
+    awaitingChoice = true;
+    controls.innerHTML = '';
+    Object.keys(responses).forEach(opt => {
+      const btn = document.createElement('button');
+      btn.className = 'option-btn';
+      btn.textContent = opt;
+      btn.onclick = () => handleReflectionChoice(opt, responses[opt]);
+      controls.appendChild(btn);
+    });
   }
 
   function updateColors() {


### PR DESCRIPTION
## Summary
- extend `Sage` with closing question, responses and farewell
- when conversation returns to Sage, ask the reflection question
- show comment, farewell, and close the chat after user choice

## Testing
- `node --check chatbots/ethical-chatbot.js`
- `node --check chatbots/ethics-chat-engine.js`

------
https://chatgpt.com/codex/tasks/task_e_685b7cc466c883228d23e0aea82dd2a3