### PR TITLE
Switch Sherlock page to chat-based layout

### DIFF
--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -997,6 +997,16 @@ button {
   color: #fff;
 }
 
+.speaker-sherlock {
+  background: #607d8b;
+  color: #fff;
+}
+
+.speaker-watson {
+  background: #8d6e63;
+  color: #fff;
+}
+
 .typing {
   opacity: 0.6;
   font-style: italic;

--- a/sherlock-mystery/sherlock-chat.js
+++ b/sherlock-mystery/sherlock-chat.js
@@ -1,0 +1,252 @@
+const sherlockSteps = [
+  {
+    messages: [
+      { speaker: "Sherlock", text: "Professor Russell's manuscript has vanished. Watson and I could use your help." },
+      { speaker: "Watson", text: "Shall we begin investigating?" }
+    ],
+    choices: ["Yes, let's begin.", "Not now"],
+    responses: {
+      "Yes, let's begin.": [
+        { speaker: "Sherlock", text: "Excellent. Let's look at the evidence." }
+      ],
+      "Not now": [
+        { speaker: "Sherlock", text: "Very well. Come back when you're ready." },
+        { speaker: "System", text: "Chat closed", className: "chat-notice" }
+      ]
+    },
+    endChoices: ["Not now"]
+  },
+  {
+    messages: [
+      { speaker: "Watson", text: "We have several clues. Which one should we examine?" }
+    ],
+    choices: [
+      "Housekeeper's Testimony",
+      "Beatrice Lowell's Statement",
+      "Charles Finch's Alibi",
+      "Study Door Security"
+    ],
+    responses: {
+      "Housekeeper's Testimony": [
+        { speaker: "Watson", text: "The housekeeper observed Alexander Greaves quietly reading in the library, far from the study, when the manuscript disappeared." }
+      ],
+      "Beatrice Lowell's Statement": [
+        { speaker: "Watson", text: "Beatrice claims she saw Alexander near the professor's study precisely when the housekeeper saw him in the library." }
+      ],
+      "Charles Finch's Alibi": [
+        { speaker: "Watson", text: "Charles insists he remained at home all morning, yet his neighbor spotted him rushing away from his home around the time of the theft." }
+      ],
+      "Study Door Security": [
+        { speaker: "Watson", text: "Professor Russell's study can only be accessed using a unique brass key, and Charles Finch is known to have borrowed the key a day earlier, claiming he had lost his own." }
+      ]
+    },
+    after: [
+      { speaker: "Sherlock", text: "Keep that in mind. Now let's test your deductions." }
+    ]
+  },
+  {
+    messages: [
+      { speaker: "Sherlock", text: "Which two statements directly contradict each other?" }
+    ],
+    choices: [
+      "Housekeeper’s statement vs. Beatrice’s statement about Alexander’s location.",
+      "Charles’s alibi vs. neighbor’s observation.",
+      "Alexander vs. Charles regarding study access."
+    ],
+    responses: {
+      "Housekeeper’s statement vs. Beatrice’s statement about Alexander’s location.": [
+        { speaker: "Sherlock", text: "Not quite. Those could both be true." }
+      ],
+      "Charles’s alibi vs. neighbor’s observation.": [
+        { speaker: "Sherlock", text: "Correct. Charles's alibi conflicts with the neighbor's account." }
+      ],
+      "Alexander vs. Charles regarding study access.": [
+        { speaker: "Sherlock", text: "Consider the evidence carefully." }
+      ]
+    }
+  },
+  {
+    messages: [
+      { speaker: "Sherlock", text: "Which piece of evidence most strongly implicates a suspect?" }
+    ],
+    choices: [
+      "The housekeeper placing Alexander away from the study.",
+      "Beatrice accusing Alexander of being near the study.",
+      "Charles’s key access and contradictory alibi evidence."
+    ],
+    responses: {
+      "The housekeeper placing Alexander away from the study.": [
+        { speaker: "Sherlock", text: "That weakens suspicion of Alexander." }
+      ],
+      "Beatrice accusing Alexander of being near the study.": [
+        { speaker: "Sherlock", text: "Interesting, but not our strongest lead." }
+      ],
+      "Charles’s key access and contradictory alibi evidence.": [
+        { speaker: "Sherlock", text: "Exactly. Those facts point strongly toward Charles." }
+      ]
+    }
+  },
+  {
+    messages: [
+      { speaker: "Sherlock", text: "Considering the evidence and contradictions, who is the most likely culprit?" }
+    ],
+    choices: ["Alexander Greaves", "Beatrice Lowell", "Charles Finch"],
+    responses: {
+      "Alexander Greaves": [
+        { speaker: "Sherlock", text: "Alexander has an alibi placing him elsewhere." }
+      ],
+      "Beatrice Lowell": [
+        { speaker: "Sherlock", text: "Beatrice raised suspicion, but little supports her guilt." }
+      ],
+      "Charles Finch": [
+        { speaker: "Sherlock", text: "Indeed. The evidence against Charles is compelling." }
+      ]
+    }
+  },
+  {
+    messages: [
+      { speaker: "Sherlock", text: "Excellent deduction! You've concluded that Charles Finch took Professor Russell's manuscript." },
+      { speaker: "Sherlock", text: "Reflect on how each clue fit together to reveal the truth." },
+      { speaker: "System", text: "Chat closed", className: "chat-notice" }
+    ]
+  }
+];
+
+(function() {
+  const chatBox = document.getElementById('chat-box');
+  const controls = document.getElementById('chat-controls');
+  const extras = document.getElementById('chat-extras');
+  const colorToggle = extras ? extras.querySelector('#color-toggle') : null;
+  const emojiButtons = extras ? extras.querySelectorAll('.emoji-btn') : [];
+  let stepIndex = 0;
+  let awaitingChoice = false;
+  const speakerClasses = {
+    'Sherlock': 'speaker-sherlock',
+    'Watson': 'speaker-watson'
+  };
+  const colorSchemes = ['speaker', 'blue', 'teal', 'purple'];
+  let colorSchemeIndex = 0;
+
+  function getTimestamp() {
+    return new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  }
+
+  async function addMessage(speaker, text, className) {
+    if (!className) {
+      className = speakerClasses[speaker] || 'chat-bot';
+    }
+    const div = document.createElement('div');
+    div.dataset.speaker = speaker;
+    div.dataset.speakerClass = className;
+    const baseClass = speaker === 'You' ? 'chat-user' : 'chat-bot';
+    const scheme = colorSchemes[colorSchemeIndex];
+    div.className = `chat-message ${baseClass}`;
+    if (scheme === 'speaker' && className && baseClass !== className) {
+      div.classList.add(className);
+    } else if (scheme !== 'speaker') {
+      div.classList.add(`theme-${scheme}`);
+    }
+    const time = `<div class="timestamp">${getTimestamp()}</div>`;
+    if (speaker !== 'You') {
+      div.innerHTML = `<strong>${speaker}:</strong> <span class="typing">…</span>`;
+      chatBox.appendChild(div);
+      chatBox.scrollTop = chatBox.scrollHeight;
+      const delay = 1200 + Math.random() * Math.min(2500, text.length * 30);
+      await new Promise(res => setTimeout(res, delay));
+      div.innerHTML = `<strong>${speaker}:</strong> ${text}${time}`;
+      chatBox.scrollTop = chatBox.scrollHeight;
+    } else {
+      div.innerHTML = `<strong>${speaker}:</strong> ${text}${time}`;
+      chatBox.appendChild(div);
+      chatBox.scrollTop = chatBox.scrollHeight;
+    }
+  }
+
+  function showChoices(step) {
+    awaitingChoice = true;
+    controls.innerHTML = '';
+    step.choices.forEach(opt => {
+      const btn = document.createElement('button');
+      btn.className = 'option-btn';
+      btn.innerText = opt;
+      btn.onclick = () => handleChoice(opt);
+      controls.appendChild(btn);
+    });
+  }
+
+  async function handleChoice(choice) {
+    if (!awaitingChoice) return;
+    awaitingChoice = false;
+    controls.querySelectorAll('button').forEach(b => b.disabled = true);
+    await addMessage('You', choice, 'chat-user');
+    const step = sherlockSteps[stepIndex];
+    controls.innerHTML = '';
+    const replies = step.responses ? (step.responses[choice] || []) : [];
+    for (const m of replies) {
+      await addMessage(m.speaker, m.text, m.className);
+    }
+    if (step.after) {
+      for (const m of step.after) {
+        await addMessage(m.speaker, m.text, m.className);
+      }
+    }
+    if (step.endChoices && step.endChoices.includes(choice)) {
+      return;
+    }
+    stepIndex++;
+    if (stepIndex < sherlockSteps.length) {
+      setTimeout(showStep, 500);
+    }
+  }
+
+  function updateColors() {
+    const scheme = colorSchemes[colorSchemeIndex];
+    const msgs = chatBox.querySelectorAll('.chat-message');
+    msgs.forEach(m => {
+      const speakerClass = m.dataset.speakerClass;
+      const speaker = m.dataset.speaker;
+      const base = speaker === 'You' ? 'chat-user' : 'chat-bot';
+      m.className = `chat-message ${base}`;
+      if (scheme === 'speaker' && speakerClass && base !== speakerClass) {
+        m.classList.add(speakerClass);
+      } else if (scheme !== 'speaker') {
+        m.classList.add(`theme-${scheme}`);
+      }
+    });
+  }
+
+  if (colorToggle) {
+    colorToggle.addEventListener('click', () => {
+      colorSchemeIndex = (colorSchemeIndex + 1) % colorSchemes.length;
+      updateColors();
+    });
+  }
+
+  if (emojiButtons.length) {
+    emojiButtons.forEach(btn => {
+      btn.addEventListener('click', () => addMessage('You', btn.textContent, 'chat-user'));
+    });
+  }
+
+  async function showStep() {
+    const step = sherlockSteps[stepIndex];
+    for (const m of step.messages) {
+      await addMessage(m.speaker, m.text, m.className);
+    }
+    if (step.choices) {
+      showChoices(step);
+    } else {
+      if (step.after) {
+        for (const m of step.after) {
+          await addMessage(m.speaker, m.text, m.className);
+        }
+      }
+      stepIndex++;
+      if (stepIndex < sherlockSteps.length) {
+        setTimeout(showStep, 500);
+      }
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', showStep);
+})();

--- a/sherlock-mystery/sherlock.html
+++ b/sherlock-mystery/sherlock.html
@@ -13,29 +13,18 @@
   </nav>
   <header id="page-header" data-default-course="criticalThinking">Course • Activity</header>
   <div class="container">
-    <h1>Sherlock Holmes Mystery</h1>
-    <div id="intro-section">
-      <p>Welcome to 221B Baker Street! Dr. Watson is away and Sherlock Holmes needs your help to investigate the disappearance of Professor Russell's philosophy manuscript.</p>
-      <button id="start-investigation">Start Investigation</button>
+    <h1>Sherlock Holmes Mystery Chat</h1>
+    <p class="instructions">Chat with Sherlock and Watson to solve the case.</p>
+    <div id="chat-box"></div>
+    <div id="chat-extras">
+      <button class="emoji-btn">😊</button>
+      <button class="emoji-btn">👍</button>
+      <button class="emoji-btn">😢</button>
+      <button id="color-toggle">Change Color Scheme</button>
     </div>
-
-    <div id="clue-section" class="hidden" hidden>
-      <h2>Clues</h2>
-      <div id="clue-buttons" class="mc-options"></div>
-      <div id="clue-text" style="margin-top:10px;"></div>
-      <button id="analyze-evidence" class="hidden" hidden>Analyze Evidence</button>
-    </div>
-
-    <div id="puzzle-section" class="hidden" hidden>
-      <p id="puzzle-question"></p>
-      <div id="puzzle-options" class="mc-options"></div>
-      <div id="puzzle-feedback" class="hidden" hidden></div>
-      <button id="next-puzzle" class="hidden" hidden>Next</button>
-    </div>
-
-    <div id="resolution-section" class="hidden" hidden></div>
+    <div id="chat-controls"></div>
   </div>
-  <script src="sherlock.js"></script>
+  <script src="sherlock-chat.js"></script>
   <script src="../explain.js"></script>
   <script src="../keyterms-sidebar.js"></script>
   <script src="../page-header.js"></script>


### PR DESCRIPTION
## Summary
- convert Sherlock mystery page to use chat UI
- add new chat script for step-based investigation
- define speaker colors for Sherlock and Watson

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b7cca58b48322994bb8f6d251588f