### PR TITLE
Fix course parameter retrieval

### DIFF
--- a/page-header.js
+++ b/page-header.js
@@ -122,7 +122,7 @@ function ensureMainId() {
 function initPageHeader() {
   const params = new URLSearchParams(window.location.search);
   const header = document.getElementById('page-header');
-  let courseKey = params.get('course');
+  let courseKey = params.get('course') || params.get('topic');
   if (!courseKey && header) {
     courseKey = header.dataset.defaultCourse;
   }


### PR DESCRIPTION
## Summary
- extend `courseKey` detection in `initPageHeader` to read a `topic` query parameter when no `course` parameter is present

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685b7dfe442483229ba0f29cbac15058