### PR TITLE
Improve chat markup

### DIFF
--- a/chatbots/ethics-chat-engine.js
+++ b/chatbots/ethics-chat-engine.js
@@ -56,17 +56,17 @@
       : '';
     const time = `<div class="timestamp">${getTimestamp()}</div>`;
     if (speaker !== 'You') {
-      div.innerHTML = `${img}<strong>${speaker}:</strong> <span class="typing">…</span>`;
+      div.innerHTML = `${img}<div class="chat-content"><strong class="speaker-name">${speaker}:</strong> <span class="typing">…</span></div>`;
       chatBox.appendChild(div);
       chatBox.scrollTop = chatBox.scrollHeight;
       const baseDelay = 1000;
       const extraDelay = Math.min(2000, text.length * 20);
       const delay = baseDelay + Math.random() * extraDelay;
       await new Promise(res => setTimeout(res, delay));
-      div.innerHTML = `${img}<strong>${speaker}:</strong> ${text}${time}`;
+      div.innerHTML = `${img}<div class="chat-content"><strong class="speaker-name">${speaker}:</strong><div class="chat-text">${text}</div>${time}</div>`;
       chatBox.scrollTop = chatBox.scrollHeight;
     } else {
-      div.innerHTML = `${img}<strong>${speaker}:</strong> ${text}${time}`;
+      div.innerHTML = `${img}<div class="chat-content"><strong class="speaker-name">${speaker}:</strong><div class="chat-text">${text}</div>${time}</div>`;
       chatBox.appendChild(div);
       chatBox.scrollTop = chatBox.scrollHeight;
     }

--- a/chatbots/intro-philosophy-chatbot-revised.js
+++ b/chatbots/intro-philosophy-chatbot-revised.js
@@ -252,17 +252,17 @@ const philosophyChatSteps = [
       : '';
     const time = `<div class="timestamp">${getTimestamp()}</div>`;
     if (speaker !== 'You') {
-      div.innerHTML = `${img}<strong>${speaker}:</strong> <span class="typing">…</span>`;
+      div.innerHTML = `${img}<div class="chat-content"><strong class="speaker-name">${speaker}:</strong> <span class="typing">…</span></div>`;
       chatBox.appendChild(div);
       chatBox.scrollTop = chatBox.scrollHeight;
       const baseDelay = 1200;
       const extraDelay = Math.min(2500, text.length * 30);
       const delay = baseDelay + Math.random() * extraDelay;
       await new Promise(res => setTimeout(res, delay));
-      div.innerHTML = `${img}<strong>${speaker}:</strong> ${text}${time}`;
+      div.innerHTML = `${img}<div class="chat-content"><strong class="speaker-name">${speaker}:</strong><div class="chat-text">${text}</div>${time}</div>`;
       chatBox.scrollTop = chatBox.scrollHeight;
     } else {
-      div.innerHTML = `${img}<strong>${speaker}:</strong> ${text}${time}`;
+      div.innerHTML = `${img}<div class="chat-content"><strong class="speaker-name">${speaker}:</strong><div class="chat-text">${text}</div>${time}</div>`;
       chatBox.appendChild(div);
       chatBox.scrollTop = chatBox.scrollHeight;
     }

--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -844,6 +844,21 @@ button {
   margin-right: 6px;
 }
 
+.chat-content {
+  display: flex;
+  flex-direction: column;
+}
+
+.speaker-name {
+  display: block;
+  font-weight: bold;
+}
+
+.chat-text {
+  margin-top: 2px;
+  display: block;
+}
+
 .chat-message.chat-user {
   justify-content: flex-end;
   margin-left: auto;

--- a/sherlock-mystery/sherlock-chat.js
+++ b/sherlock-mystery/sherlock-chat.js
@@ -148,15 +148,15 @@ const sherlockSteps = [
     }
     const time = `<div class="timestamp">${getTimestamp()}</div>`;
     if (speaker !== 'You') {
-      div.innerHTML = `<strong>${speaker}:</strong> <span class="typing">…</span>`;
+      div.innerHTML = `<div class="chat-content"><strong class="speaker-name">${speaker}:</strong> <span class="typing">…</span></div>`;
       chatBox.appendChild(div);
       chatBox.scrollTop = chatBox.scrollHeight;
       const delay = 1200 + Math.random() * Math.min(2500, text.length * 30);
       await new Promise(res => setTimeout(res, delay));
-      div.innerHTML = `<strong>${speaker}:</strong> ${text}${time}`;
+      div.innerHTML = `<div class="chat-content"><strong class="speaker-name">${speaker}:</strong><div class="chat-text">${text}</div>${time}</div>`;
       chatBox.scrollTop = chatBox.scrollHeight;
     } else {
-      div.innerHTML = `<strong>${speaker}:</strong> ${text}${time}`;
+      div.innerHTML = `<div class="chat-content"><strong class="speaker-name">${speaker}:</strong><div class="chat-text">${text}</div>${time}</div>`;
       chatBox.appendChild(div);
       chatBox.scrollTop = chatBox.scrollHeight;
     }


### PR DESCRIPTION
## Summary
- wrap chat text in a dedicated div
- ensure speaker names break onto new lines
- style new chat wrappers

## Testing
- `npm test` *(fails: ENOENT)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685b7df14cec8322a636c2a900ad2bf2