### PR TITLE
Support multiple speaker color schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This repository contains a set of lightweight browser games that let you review 
 - Ethics Chat page with rotating philosopher perspectives
 - Intro Philosophy Chat covering ancient Greek thinkers
 - Chat pages support optional profile pictures stored in `assets/images/`; add your own PNG files (e.g., `aristotle.png`)
+- Chats include a color scheme toggle cycling through **speaker**, **blue**, **teal**, and **purple** themes so philosophers remain visually distinct
 - Writing games now include a "Start Your Own Project" mode with templates that can be exported as PDF, DOCX, or PNG. Thesis prompts are editable and you can export just the thesis or a combined document with your answers.
 
 ## Getting Started

--- a/chatbots/ethics-chat-engine.js
+++ b/chatbots/ethics-chat-engine.js
@@ -19,6 +19,33 @@
     'Sage': 'speaker-student'
   };
 
+  const schemeSpeakerClasses = {
+    blue: {
+      'John Stuart Mill': 'blue-mill',
+      'Immanuel Kant': 'blue-kant',
+      'St. Thomas Aquinas': 'blue-aquinas',
+      'Aristotle': 'blue-aristotle',
+      'Nel Noddings': 'blue-noddings',
+      'Sage': 'blue-student'
+    },
+    teal: {
+      'John Stuart Mill': 'teal-mill',
+      'Immanuel Kant': 'teal-kant',
+      'St. Thomas Aquinas': 'teal-aquinas',
+      'Aristotle': 'teal-aristotle',
+      'Nel Noddings': 'teal-noddings',
+      'Sage': 'teal-student'
+    },
+    purple: {
+      'John Stuart Mill': 'purple-mill',
+      'Immanuel Kant': 'purple-kant',
+      'St. Thomas Aquinas': 'purple-aquinas',
+      'Aristotle': 'purple-aristotle',
+      'Nel Noddings': 'purple-noddings',
+      'Sage': 'purple-student'
+    }
+  };
+
   const speakerImages = {
     'You': '../assets/images/profile.png',
     'John Stuart Mill': '../assets/images/mill.png',
@@ -45,9 +72,13 @@
     div.dataset.speakerClass = className;
     const baseClass = speaker === 'You' ? 'chat-user' : 'chat-bot';
     const scheme = colorSchemes[colorSchemeIndex];
+    const schemeMap = schemeSpeakerClasses[scheme] || {};
+    const schemeClass = schemeMap[speaker];
     div.className = `chat-message ${baseClass}`;
     if (scheme === 'speaker' && className && baseClass !== className) {
       div.classList.add(className);
+    } else if (schemeClass) {
+      div.classList.add(schemeClass);
     } else if (scheme !== 'speaker') {
       div.classList.add(`theme-${scheme}`);
     }
@@ -184,9 +215,13 @@
       const speakerClass = m.dataset.speakerClass;
       const speaker = m.dataset.speaker;
       const base = speaker === 'You' ? 'chat-user' : 'chat-bot';
+      const schemeMap = schemeSpeakerClasses[scheme] || {};
+      const schemeClass = schemeMap[speaker];
       m.className = `chat-message ${base}`;
       if (scheme === 'speaker' && speakerClass && base !== speakerClass) {
         m.classList.add(speakerClass);
+      } else if (schemeClass) {
+        m.classList.add(schemeClass);
       } else if (scheme !== 'speaker') {
         m.classList.add(`theme-${scheme}`);
       }

--- a/chatbots/intro-philosophy-chatbot-revised.js
+++ b/chatbots/intro-philosophy-chatbot-revised.js
@@ -215,6 +215,33 @@ const philosophyChatSteps = [
     'Aristotle': 'speaker-aristotle'
   };
 
+  const schemeSpeakerClasses = {
+    blue: {
+      'Sage': 'blue-student',
+      'Thales': 'blue-thales',
+      'Heraclitus': 'blue-heraclitus',
+      'Socrates': 'blue-socrates',
+      'Plato': 'blue-plato',
+      'Aristotle': 'blue-aristotle'
+    },
+    teal: {
+      'Sage': 'teal-student',
+      'Thales': 'teal-thales',
+      'Heraclitus': 'teal-heraclitus',
+      'Socrates': 'teal-socrates',
+      'Plato': 'teal-plato',
+      'Aristotle': 'teal-aristotle'
+    },
+    purple: {
+      'Sage': 'purple-student',
+      'Thales': 'purple-thales',
+      'Heraclitus': 'purple-heraclitus',
+      'Socrates': 'purple-socrates',
+      'Plato': 'purple-plato',
+      'Aristotle': 'purple-aristotle'
+    }
+  };
+
   const speakerImages = {
     'You': '../assets/images/profile.png',
     'Sage': '../assets/images/student.png',
@@ -241,9 +268,13 @@ const philosophyChatSteps = [
     div.dataset.speakerClass = className;
     const baseClass = speaker === 'You' ? 'chat-user' : 'chat-bot';
     const scheme = colorSchemes[colorSchemeIndex];
+    const schemeMap = schemeSpeakerClasses[scheme] || {};
+    const schemeClass = schemeMap[speaker];
     div.className = `chat-message ${baseClass}`;
     if (scheme === 'speaker' && className && baseClass !== className) {
       div.classList.add(className);
+    } else if (schemeClass) {
+      div.classList.add(schemeClass);
     } else if (scheme !== 'speaker') {
       div.classList.add(`theme-${scheme}`);
     }
@@ -312,9 +343,13 @@ const philosophyChatSteps = [
       const speakerClass = m.dataset.speakerClass;
       const speaker = m.dataset.speaker;
       const base = speaker === 'You' ? 'chat-user' : 'chat-bot';
+      const schemeMap = schemeSpeakerClasses[scheme] || {};
+      const schemeClass = schemeMap[speaker];
       m.className = `chat-message ${base}`;
       if (scheme === 'speaker' && speakerClass && base !== speakerClass) {
         m.classList.add(speakerClass);
+      } else if (schemeClass) {
+        m.classList.add(schemeClass);
       } else if (scheme !== 'speaker') {
         m.classList.add(`theme-${scheme}`);
       }

--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -1022,6 +1022,46 @@ button {
   color: #fff;
 }
 
+/* Scheme-specific speaker colors */
+.blue-mill { background: #90caf9; color: #000; }
+.blue-kant { background: #64b5f6; color: #000; }
+.blue-aquinas { background: #42a5f5; color: #fff; }
+.blue-aristotle { background: #2196f3; color: #fff; }
+.blue-noddings { background: #1e88e5; color: #fff; }
+.blue-student { background: #1976d2; color: #fff; }
+.blue-thales { background: #1565c0; color: #fff; }
+.blue-heraclitus { background: #0d47a1; color: #fff; }
+.blue-socrates { background: #82b1ff; color: #000; }
+.blue-plato { background: #5c6bc0; color: #fff; }
+.blue-sherlock { background: #3949ab; color: #fff; }
+.blue-watson { background: #283593; color: #fff; }
+
+.teal-mill { background: #80cbc4; color: #000; }
+.teal-kant { background: #4db6ac; color: #000; }
+.teal-aquinas { background: #26a69a; color: #fff; }
+.teal-aristotle { background: #009688; color: #fff; }
+.teal-noddings { background: #00897b; color: #fff; }
+.teal-student { background: #00796b; color: #fff; }
+.teal-thales { background: #00695c; color: #fff; }
+.teal-heraclitus { background: #004d40; color: #fff; }
+.teal-socrates { background: #a7ffeb; color: #000; }
+.teal-plato { background: #64ffda; color: #000; }
+.teal-sherlock { background: #1de9b6; color: #000; }
+.teal-watson { background: #00bfa5; color: #fff; }
+
+.purple-mill { background: #ce93d8; color: #000; }
+.purple-kant { background: #ba68c8; color: #fff; }
+.purple-aquinas { background: #ab47bc; color: #fff; }
+.purple-aristotle { background: #9c27b0; color: #fff; }
+.purple-noddings { background: #8e24aa; color: #fff; }
+.purple-student { background: #7b1fa2; color: #fff; }
+.purple-thales { background: #6a1b9a; color: #fff; }
+.purple-heraclitus { background: #4a148c; color: #fff; }
+.purple-socrates { background: #e1bee7; color: #000; }
+.purple-plato { background: #b39ddb; color: #000; }
+.purple-sherlock { background: #9575cd; color: #000; }
+.purple-watson { background: #7e57c2; color: #fff; }
+
 .typing {
   opacity: 0.6;
   font-style: italic;

--- a/sherlock-mystery/sherlock-chat.js
+++ b/sherlock-mystery/sherlock-chat.js
@@ -124,6 +124,20 @@ const sherlockSteps = [
     'Sherlock': 'speaker-sherlock',
     'Watson': 'speaker-watson'
   };
+  const schemeSpeakerClasses = {
+    blue: {
+      'Sherlock': 'blue-sherlock',
+      'Watson': 'blue-watson'
+    },
+    teal: {
+      'Sherlock': 'teal-sherlock',
+      'Watson': 'teal-watson'
+    },
+    purple: {
+      'Sherlock': 'purple-sherlock',
+      'Watson': 'purple-watson'
+    }
+  };
   const colorSchemes = ['speaker', 'blue', 'teal', 'purple'];
   let colorSchemeIndex = 0;
 
@@ -140,9 +154,13 @@ const sherlockSteps = [
     div.dataset.speakerClass = className;
     const baseClass = speaker === 'You' ? 'chat-user' : 'chat-bot';
     const scheme = colorSchemes[colorSchemeIndex];
+    const schemeMap = schemeSpeakerClasses[scheme] || {};
+    const schemeClass = schemeMap[speaker];
     div.className = `chat-message ${baseClass}`;
     if (scheme === 'speaker' && className && baseClass !== className) {
       div.classList.add(className);
+    } else if (schemeClass) {
+      div.classList.add(schemeClass);
     } else if (scheme !== 'speaker') {
       div.classList.add(`theme-${scheme}`);
     }
@@ -206,9 +224,13 @@ const sherlockSteps = [
       const speakerClass = m.dataset.speakerClass;
       const speaker = m.dataset.speaker;
       const base = speaker === 'You' ? 'chat-user' : 'chat-bot';
+      const schemeMap = schemeSpeakerClasses[scheme] || {};
+      const schemeClass = schemeMap[speaker];
       m.className = `chat-message ${base}`;
       if (scheme === 'speaker' && speakerClass && base !== speakerClass) {
         m.classList.add(speakerClass);
+      } else if (schemeClass) {
+        m.classList.add(schemeClass);
       } else if (scheme !== 'speaker') {
         m.classList.add(`theme-${scheme}`);
       }


### PR DESCRIPTION
## Summary
- document color scheme toggle in README
- style chat messages with scheme-specific speaker classes
- keep philosophers color-coded when switching schemes

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685b810fc2548322960d04175ea689d9