### PR TITLE
Fix keyterms sidebar toggle propagation

### DIFF
--- a/keyterms-sidebar.js
+++ b/keyterms-sidebar.js
@@ -73,7 +73,8 @@ function createKeyTermsSidebar(courseKey) {
   const color = courseColors[courseKey] || '#009688';
   sidebar.style.borderLeftColor = color;
   toggle.style.background = color;
-  toggle.addEventListener('click', () => {
+  toggle.addEventListener('click', (event) => {
+    event.stopPropagation();
     const collapsed = sidebar.classList.toggle('collapsed');
     toggle.innerHTML = collapsed ? '&lsaquo;' : '&rsaquo;';
   });


### PR DESCRIPTION
## Summary
- stop click propagation on the keyterms sidebar toggle so sidebar
  doesn't immediately re-close when clicked

## Testing
- `node --check keyterms-sidebar.js`


------
https://chatgpt.com/codex/tasks/task_e_685b828dbb7483229f27c5d2cfa544d3