### PR TITLE
Handle multiple contradictions in Sherlock puzzle

### DIFF
--- a/sherlock-mystery/sherlock-chat.js
+++ b/sherlock-mystery/sherlock-chat.js
@@ -44,10 +44,10 @@ const case1Steps = [
     ],
     responses: {
       "Housekeeper’s statement vs. Beatrice’s statement about Alexander’s location.": [
-        { speaker: "Sherlock", text: "Not quite. Those could both be true." }
+        { speaker: "Sherlock", text: "Yes, those accounts clash about where Alexander was, though Charles's alibi issue seems more revealing." }
       ],
       "Charles’s alibi vs. neighbor’s observation.": [
-        { speaker: "Sherlock", text: "Correct. Charles's alibi conflicts with the neighbor's account." }
+        { speaker: "Sherlock", text: "Exactly. Charles's alibi conflicts with the neighbor's account." }
       ],
       "Alexander vs. Charles regarding study access.": [
         { speaker: "Sherlock", text: "Consider the evidence carefully." }

--- a/sherlock-mystery/sherlock.js
+++ b/sherlock-mystery/sherlock.js
@@ -13,7 +13,11 @@ const puzzles = [
       "Charles’s alibi vs. neighbor’s observation.",
       "Alexander vs. Charles regarding study access."
     ],
-    correct: 1
+    correct: [0, 1],
+    feedback: {
+      0: "Those statements about Alexander can't both be true, though Charles's alibi contradiction is stronger.",
+      1: "Right. Charles's alibi conflicts with his neighbor's observation."
+    }
   },
   {
     question: "Which piece of evidence most strongly implicates a suspect?",
@@ -73,11 +77,14 @@ function showPuzzle() {
 function selectOption(choice) {
   const pz = puzzles[currentPuzzle];
   const feedback = document.getElementById('puzzle-feedback');
-  if (choice === pz.correct) {
-    feedback.innerHTML = '<strong>Correct!</strong>';
+  const correctChoices = Array.isArray(pz.correct) ? pz.correct : [pz.correct];
+  const isCorrect = correctChoices.includes(choice);
+  const custom = pz.feedback && pz.feedback[choice];
+  if (isCorrect) {
+    feedback.innerHTML = `<strong>Correct!</strong> ${custom ? custom : ''}`;
     feedback.style.color = '#4caf50';
   } else {
-    feedback.innerHTML = 'Incorrect.';
+    feedback.innerHTML = custom ? custom : 'Incorrect.';
     feedback.style.color = '#c62828';
   }
   feedback.classList.remove('hidden');   feedback.hidden = false;


### PR DESCRIPTION
## Summary
- accept two contradictory statements in the Sherlock mystery puzzle
- clarify Sherlock's chat responses about the conflicting testimonies
- provide specific feedback when either contradiction is selected

## Testing
- `node --check sherlock-mystery/sherlock.js`
- `node --check sherlock-mystery/sherlock-chat.js`

------
https://chatgpt.com/codex/tasks/task_e_685b8a0826788322879761b107051d4e