### PR TITLE
Fix system message formatting across color schemes

### DIFF
--- a/chatbots/ethics-chat-engine.js
+++ b/chatbots/ethics-chat-engine.js
@@ -75,7 +75,9 @@
     const schemeMap = schemeSpeakerClasses[scheme] || {};
     const schemeClass = schemeMap[speaker];
     div.className = `chat-message ${baseClass}`;
-    if (scheme === 'speaker' && className && baseClass !== className) {
+    if (speaker === 'System' || className === 'chat-notice') {
+      div.classList.add('chat-notice');
+    } else if (scheme === 'speaker' && className && baseClass !== className) {
       div.classList.add(className);
     } else if (schemeClass) {
       div.classList.add(schemeClass);
@@ -218,7 +220,9 @@
       const schemeMap = schemeSpeakerClasses[scheme] || {};
       const schemeClass = schemeMap[speaker];
       m.className = `chat-message ${base}`;
-      if (scheme === 'speaker' && speakerClass && base !== speakerClass) {
+      if (speaker === 'System' || speakerClass === 'chat-notice') {
+        m.classList.add('chat-notice');
+      } else if (scheme === 'speaker' && speakerClass && base !== speakerClass) {
         m.classList.add(speakerClass);
       } else if (schemeClass) {
         m.classList.add(schemeClass);

--- a/chatbots/intro-philosophy-chatbot-revised.js
+++ b/chatbots/intro-philosophy-chatbot-revised.js
@@ -271,7 +271,9 @@ const philosophyChatSteps = [
     const schemeMap = schemeSpeakerClasses[scheme] || {};
     const schemeClass = schemeMap[speaker];
     div.className = `chat-message ${baseClass}`;
-    if (scheme === 'speaker' && className && baseClass !== className) {
+    if (speaker === 'System' || className === 'chat-notice') {
+      div.classList.add('chat-notice');
+    } else if (scheme === 'speaker' && className && baseClass !== className) {
       div.classList.add(className);
     } else if (schemeClass) {
       div.classList.add(schemeClass);
@@ -346,7 +348,9 @@ const philosophyChatSteps = [
       const schemeMap = schemeSpeakerClasses[scheme] || {};
       const schemeClass = schemeMap[speaker];
       m.className = `chat-message ${base}`;
-      if (scheme === 'speaker' && speakerClass && base !== speakerClass) {
+      if (speaker === 'System' || speakerClass === 'chat-notice') {
+        m.classList.add('chat-notice');
+      } else if (scheme === 'speaker' && speakerClass && base !== speakerClass) {
         m.classList.add(speakerClass);
       } else if (schemeClass) {
         m.classList.add(schemeClass);

--- a/sherlock-mystery/sherlock-chat.js
+++ b/sherlock-mystery/sherlock-chat.js
@@ -378,7 +378,9 @@ localStorage.setItem('sherlock-case-index', (caseIndex + 1) % sherlockCases.leng
     const schemeMap = schemeSpeakerClasses[scheme] || {};
     const schemeClass = schemeMap[speaker];
     div.className = `chat-message ${baseClass}`;
-    if (scheme === 'speaker' && className && baseClass !== className) {
+    if (speaker === 'System' || className === 'chat-notice') {
+      div.classList.add('chat-notice');
+    } else if (scheme === 'speaker' && className && baseClass !== className) {
       div.classList.add(className);
     } else if (schemeClass) {
       div.classList.add(schemeClass);
@@ -463,7 +465,9 @@ localStorage.setItem('sherlock-case-index', (caseIndex + 1) % sherlockCases.leng
       const schemeMap = schemeSpeakerClasses[scheme] || {};
       const schemeClass = schemeMap[speaker];
       m.className = `chat-message ${base}`;
-      if (scheme === 'speaker' && speakerClass && base !== speakerClass) {
+      if (speaker === 'System' || speakerClass === 'chat-notice') {
+        m.classList.add('chat-notice');
+      } else if (scheme === 'speaker' && speakerClass && base !== speakerClass) {
         m.classList.add(speakerClass);
       } else if (schemeClass) {
         m.classList.add(schemeClass);


### PR DESCRIPTION
## Summary
- preserve `chat-notice` style when adding messages
- keep system notices gray when toggling color schemes

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685bf034eac883229bb1c56426f2d06a