### PR TITLE
Extend chat color scheme

### DIFF
--- a/chatbots/ethics-chat-engine.js
+++ b/chatbots/ethics-chat-engine.js
@@ -59,6 +59,14 @@
   const colorSchemes = ['speaker', 'blue', 'teal', 'purple'];
   let colorSchemeIndex = 0;
 
+  const schemeButtonColors = {
+    speaker: getComputedStyle(document.documentElement)
+      .getPropertyValue('--accent-light') || '#ce93d8',
+    blue: '#90caf9',
+    teal: '#80cbc4',
+    purple: '#ce93d8'
+  };
+
   function getTimestamp() {
     return new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
   }
@@ -115,6 +123,7 @@
       btn.onclick = () => handleChoice(option, responses[option], view);
       controls.appendChild(btn);
     });
+    updateColors();
   }
 
   async function handleChoice(option, reply, view) {
@@ -208,6 +217,7 @@
       btn.onclick = () => handleReflectionChoice(opt, responses[opt]);
       controls.appendChild(btn);
     });
+    updateColors();
   }
 
   function updateColors() {
@@ -229,6 +239,15 @@
       } else if (scheme !== 'speaker') {
         m.classList.add(`theme-${scheme}`);
       }
+    });
+    const btnColor = schemeButtonColors[scheme] || schemeButtonColors.speaker;
+    if (colorToggle) {
+      colorToggle.style.background = btnColor;
+      colorToggle.style.color = '#000';
+    }
+    controls.querySelectorAll('.option-btn').forEach(b => {
+      b.style.background = btnColor;
+      b.style.color = '#000';
     });
   }
 
@@ -311,6 +330,7 @@
         };
         controls.appendChild(btn);
       });
+      updateColors();
     });
 
     if (selected !== 'No thanks') {

--- a/chatbots/intro-philosophy-chatbot-revised.js
+++ b/chatbots/intro-philosophy-chatbot-revised.js
@@ -255,6 +255,14 @@ const philosophyChatSteps = [
   const colorSchemes = ['speaker', 'blue', 'teal', 'purple'];
   let colorSchemeIndex = 0;
 
+  const schemeButtonColors = {
+    speaker: getComputedStyle(document.documentElement)
+      .getPropertyValue('--accent-light') || '#ce93d8',
+    blue: '#90caf9',
+    teal: '#80cbc4',
+    purple: '#ce93d8'
+  };
+
   function getTimestamp() {
     return new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
   }
@@ -311,6 +319,7 @@ const philosophyChatSteps = [
       btn.onclick = () => handleChoice(opt);
       controls.appendChild(btn);
     });
+    updateColors();
   }
 
   async function handleChoice(choice) {
@@ -357,6 +366,15 @@ const philosophyChatSteps = [
       } else if (scheme !== 'speaker') {
         m.classList.add(`theme-${scheme}`);
       }
+    });
+    const btnColor = schemeButtonColors[scheme] || schemeButtonColors.speaker;
+    if (colorToggle) {
+      colorToggle.style.background = btnColor;
+      colorToggle.style.color = '#000';
+    }
+    controls.querySelectorAll('.option-btn').forEach(b => {
+      b.style.background = btnColor;
+      b.style.color = '#000';
     });
   }
 

--- a/sherlock-mystery/sherlock-chat.js
+++ b/sherlock-mystery/sherlock-chat.js
@@ -371,6 +371,14 @@ localStorage.setItem('sherlock-case-index', (caseIndex + 1) % sherlockCases.leng
   const colorSchemes = ['speaker', 'blue', 'teal', 'purple'];
   let colorSchemeIndex = 0;
 
+  const schemeButtonColors = {
+    speaker: getComputedStyle(document.documentElement)
+      .getPropertyValue('--accent-light') || '#ce93d8',
+    blue: '#90caf9',
+    teal: '#80cbc4',
+    purple: '#ce93d8'
+  };
+
   function getTimestamp() {
     return new Date().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
   }
@@ -422,6 +430,7 @@ localStorage.setItem('sherlock-case-index', (caseIndex + 1) % sherlockCases.leng
       btn.onclick = () => handleChoice(opt);
       controls.appendChild(btn);
     });
+    updateColors();
   }
 
   async function handleChoice(choice) {
@@ -491,6 +500,15 @@ localStorage.setItem('sherlock-case-index', (caseIndex + 1) % sherlockCases.leng
       } else if (scheme !== 'speaker') {
         m.classList.add(`theme-${scheme}`);
       }
+    });
+    const btnColor = schemeButtonColors[scheme] || schemeButtonColors.speaker;
+    if (colorToggle) {
+      colorToggle.style.background = btnColor;
+      colorToggle.style.color = '#000';
+    }
+    controls.querySelectorAll('.option-btn').forEach(b => {
+      b.style.background = btnColor;
+      b.style.color = '#000';
     });
   }
 


### PR DESCRIPTION
## Summary
- sync color scheme for option buttons and toggle button
- keep chat buttons consistent across color modes

## Testing
- `git diff --stat`


------
https://chatgpt.com/codex/tasks/task_e_685c03d1a438832293657b51d8b3ec8c