### PR TITLE
Fix chat color conflicts

### DIFF
--- a/chatbots/ethics-chat-engine.js
+++ b/chatbots/ethics-chat-engine.js
@@ -21,6 +21,7 @@
 
   const schemeSpeakerClasses = {
     blue: {
+      'You': 'blue-user',
       'John Stuart Mill': 'blue-mill',
       'Immanuel Kant': 'blue-kant',
       'St. Thomas Aquinas': 'blue-aquinas',
@@ -29,6 +30,7 @@
       'Sage': 'blue-student'
     },
     teal: {
+      'You': 'teal-user',
       'John Stuart Mill': 'teal-mill',
       'Immanuel Kant': 'teal-kant',
       'St. Thomas Aquinas': 'teal-aquinas',
@@ -37,6 +39,7 @@
       'Sage': 'teal-student'
     },
     purple: {
+      'You': 'purple-user',
       'John Stuart Mill': 'purple-mill',
       'Immanuel Kant': 'purple-kant',
       'St. Thomas Aquinas': 'purple-aquinas',

--- a/chatbots/intro-philosophy-chatbot-revised.js
+++ b/chatbots/intro-philosophy-chatbot-revised.js
@@ -217,6 +217,7 @@ const philosophyChatSteps = [
 
   const schemeSpeakerClasses = {
     blue: {
+      'You': 'blue-user',
       'Sage': 'blue-student',
       'Thales': 'blue-thales',
       'Heraclitus': 'blue-heraclitus',
@@ -225,6 +226,7 @@ const philosophyChatSteps = [
       'Aristotle': 'blue-aristotle'
     },
     teal: {
+      'You': 'teal-user',
       'Sage': 'teal-student',
       'Thales': 'teal-thales',
       'Heraclitus': 'teal-heraclitus',
@@ -233,6 +235,7 @@ const philosophyChatSteps = [
       'Aristotle': 'teal-aristotle'
     },
     purple: {
+      'You': 'purple-user',
       'Sage': 'purple-student',
       'Thales': 'purple-thales',
       'Heraclitus': 'purple-heraclitus',

--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -1035,6 +1035,7 @@ button {
 .blue-plato { background: #5c6bc0; color: #fff; }
 .blue-sherlock { background: #3949ab; color: #fff; }
 .blue-watson { background: #283593; color: #fff; }
+.blue-user { background: #03a9f4; color: #000; }
 
 .teal-mill { background: #80cbc4; color: #000; }
 .teal-kant { background: #4db6ac; color: #000; }
@@ -1048,6 +1049,7 @@ button {
 .teal-plato { background: #64ffda; color: #000; }
 .teal-sherlock { background: #1de9b6; color: #000; }
 .teal-watson { background: #00bfa5; color: #fff; }
+.teal-user { background: #00acc1; color: #000; }
 
 .purple-mill { background: #ce93d8; color: #000; }
 .purple-kant { background: #ba68c8; color: #fff; }
@@ -1061,6 +1063,7 @@ button {
 .purple-plato { background: #b39ddb; color: #000; }
 .purple-sherlock { background: #9575cd; color: #000; }
 .purple-watson { background: #7e57c2; color: #fff; }
+.purple-user { background: #673ab7; color: #fff; }
 
 .typing {
   opacity: 0.6;

--- a/sherlock-mystery/sherlock-chat.js
+++ b/sherlock-mystery/sherlock-chat.js
@@ -356,14 +356,17 @@ localStorage.setItem('sherlock-case-index', (caseIndex + 1) % sherlockCases.leng
   };
   const schemeSpeakerClasses = {
     blue: {
+      'You': 'blue-user',
       'Holmes': 'blue-sherlock',
       'Watson': 'blue-watson'
     },
     teal: {
+      'You': 'teal-user',
       'Holmes': 'teal-sherlock',
       'Watson': 'teal-watson'
     },
     purple: {
+      'You': 'purple-user',
       'Holmes': 'purple-sherlock',
       'Watson': 'purple-watson'
     }


### PR DESCRIPTION
## Summary
- add dedicated user colors to each chat theme
- assign user classes in color scheme maps for all chatbots

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c21a591a08322bb380f0468c16285