### PR TITLE
Add user color classes for chat schemes

### DIFF
--- a/chatbots/ethics-chat-engine.js
+++ b/chatbots/ethics-chat-engine.js
@@ -26,7 +26,8 @@
       'St. Thomas Aquinas': 'blue-aquinas',
       'Aristotle': 'blue-aristotle',
       'Nel Noddings': 'blue-noddings',
-      'Sage': 'blue-student'
+      'Sage': 'blue-student',
+      'You': 'blue-user'
     },
     teal: {
       'John Stuart Mill': 'teal-mill',
@@ -34,7 +35,8 @@
       'St. Thomas Aquinas': 'teal-aquinas',
       'Aristotle': 'teal-aristotle',
       'Nel Noddings': 'teal-noddings',
-      'Sage': 'teal-student'
+      'Sage': 'teal-student',
+      'You': 'teal-user'
     },
     purple: {
       'John Stuart Mill': 'purple-mill',
@@ -42,7 +44,8 @@
       'St. Thomas Aquinas': 'purple-aquinas',
       'Aristotle': 'purple-aristotle',
       'Nel Noddings': 'purple-noddings',
-      'Sage': 'purple-student'
+      'Sage': 'purple-student',
+      'You': 'purple-user'
     }
   };
 

--- a/chatbots/intro-philosophy-chatbot-revised.js
+++ b/chatbots/intro-philosophy-chatbot-revised.js
@@ -222,7 +222,8 @@ const philosophyChatSteps = [
       'Heraclitus': 'blue-heraclitus',
       'Socrates': 'blue-socrates',
       'Plato': 'blue-plato',
-      'Aristotle': 'blue-aristotle'
+      'Aristotle': 'blue-aristotle',
+      'You': 'blue-user'
     },
     teal: {
       'Sage': 'teal-student',
@@ -230,7 +231,8 @@ const philosophyChatSteps = [
       'Heraclitus': 'teal-heraclitus',
       'Socrates': 'teal-socrates',
       'Plato': 'teal-plato',
-      'Aristotle': 'teal-aristotle'
+      'Aristotle': 'teal-aristotle',
+      'You': 'teal-user'
     },
     purple: {
       'Sage': 'purple-student',
@@ -238,7 +240,8 @@ const philosophyChatSteps = [
       'Heraclitus': 'purple-heraclitus',
       'Socrates': 'purple-socrates',
       'Plato': 'purple-plato',
-      'Aristotle': 'purple-aristotle'
+      'Aristotle': 'purple-aristotle',
+      'You': 'purple-user'
     }
   };
 

--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -1035,6 +1035,7 @@ button {
 .blue-plato { background: #5c6bc0; color: #fff; }
 .blue-sherlock { background: #3949ab; color: #fff; }
 .blue-watson { background: #283593; color: #fff; }
+.blue-user { background: #bbdefb; color: #000; }
 
 .teal-mill { background: #80cbc4; color: #000; }
 .teal-kant { background: #4db6ac; color: #000; }
@@ -1048,6 +1049,7 @@ button {
 .teal-plato { background: #64ffda; color: #000; }
 .teal-sherlock { background: #1de9b6; color: #000; }
 .teal-watson { background: #00bfa5; color: #fff; }
+.teal-user { background: #b2dfdb; color: #000; }
 
 .purple-mill { background: #ce93d8; color: #000; }
 .purple-kant { background: #ba68c8; color: #fff; }
@@ -1061,6 +1063,7 @@ button {
 .purple-plato { background: #b39ddb; color: #000; }
 .purple-sherlock { background: #9575cd; color: #000; }
 .purple-watson { background: #7e57c2; color: #fff; }
+.purple-user { background: #e1bee7; color: #000; }
 
 .typing {
   opacity: 0.6;

--- a/sherlock-mystery/sherlock-chat.js
+++ b/sherlock-mystery/sherlock-chat.js
@@ -357,15 +357,18 @@ localStorage.setItem('sherlock-case-index', (caseIndex + 1) % sherlockCases.leng
   const schemeSpeakerClasses = {
     blue: {
       'Holmes': 'blue-sherlock',
-      'Watson': 'blue-watson'
+      'Watson': 'blue-watson',
+      'You': 'blue-user'
     },
     teal: {
       'Holmes': 'teal-sherlock',
-      'Watson': 'teal-watson'
+      'Watson': 'teal-watson',
+      'You': 'teal-user'
     },
     purple: {
       'Holmes': 'purple-sherlock',
-      'Watson': 'purple-watson'
+      'Watson': 'purple-watson',
+      'You': 'purple-user'
     }
   };
   const colorSchemes = ['speaker', 'blue', 'teal', 'purple'];


### PR DESCRIPTION
## Summary
- add `.blue-user`, `.teal-user`, and `.purple-user` colors
- map `You` to these classes in ethics, intro philosophy, and Sherlock chatbots

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_685c223a31008322b51e8742b9baf0c3