### PR TITLE
Update user chat color classes

### DIFF
--- a/jeopardy/style.css
+++ b/jeopardy/style.css
@@ -1035,7 +1035,7 @@ button {
 .blue-plato { background: #5c6bc0; color: #fff; }
 .blue-sherlock { background: #3949ab; color: #fff; }
 .blue-watson { background: #283593; color: #fff; }
-.blue-user { background: #03a9f4; color: #000; }
+.blue-user { background: #bbdefb; color: #000; }
 
 .teal-mill { background: #80cbc4; color: #000; }
 .teal-kant { background: #4db6ac; color: #000; }
@@ -1049,7 +1049,7 @@ button {
 .teal-plato { background: #64ffda; color: #000; }
 .teal-sherlock { background: #1de9b6; color: #000; }
 .teal-watson { background: #00bfa5; color: #fff; }
-.teal-user { background: #00acc1; color: #000; }
+.teal-user { background: #b2dfdb; color: #000; }
 
 .purple-mill { background: #ce93d8; color: #000; }
 .purple-kant { background: #ba68c8; color: #fff; }
@@ -1063,7 +1063,7 @@ button {
 .purple-plato { background: #b39ddb; color: #000; }
 .purple-sherlock { background: #9575cd; color: #000; }
 .purple-watson { background: #7e57c2; color: #fff; }
-.purple-user { background: #673ab7; color: #fff; }
+.purple-user { background: #e1bee7; color: #000; }
 
 .typing {
   opacity: 0.6;


### PR DESCRIPTION
## Summary
- tweak `.blue-user`, `.teal-user` and `.purple-user` to use lighter shades

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c49028fa08322b6b605016fd09391